### PR TITLE
feat: enhance get_result with detailed tool/skill execution history

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "acm-dev": {
+      "command": "npm",
+      "args": [
+        "run",
+        "dev"
+      ]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,8 @@
     "acm-dev": {
       "command": "npm",
       "args": [
-        "start"
+        "run",
+        "dev"
       ]
     }
   }

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { parseCodexOutput, parseClaudeOutput } from '../parsers.js';
+
+describe('parseCodexOutput', () => {
+  it('should parse basic Codex output with message and session_id', () => {
+    const output = `
+{"type":"thread.started","thread_id":"test-session-id"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"type":"agent_message","text":"Hello world"}}
+{"type":"turn.completed"}
+`;
+    const result = parseCodexOutput(output);
+    expect(result).toEqual({
+      message: "Hello world",
+      session_id: "test-session-id",
+      token_count: null,
+      tools: undefined
+    });
+  });
+
+  it('should extract MCP tool calls', () => {
+    const output = `
+{"type":"thread.started","thread_id":"tool-test-id"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_1","type":"mcp_tool_call","server":"acm","tool":"run","arguments":{"model":"gemini-2.5-flash","prompt":"hi"},"result":{"content":[{"text":"started","type":"text"}]},"status":"completed"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"Tool executed"}}
+{"type":"turn.completed"}
+`;
+    const result = parseCodexOutput(output);
+    
+    expect(result.message).toBe("Tool executed");
+    expect(result.session_id).toBe("tool-test-id");
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]).toEqual({
+      tool: "run",
+      server: "acm",
+      input: { model: "gemini-2.5-flash", prompt: "hi" },
+      output: { content: [{ text: "started", type: "text" }] }
+    });
+  });
+
+  it('should handle multiple tool calls', () => {
+    const output = `
+{"type":"item.completed","item":{"type":"mcp_tool_call","tool":"tool1","arguments":{"arg":1},"result":"res1"}}
+{"type":"item.completed","item":{"type":"mcp_tool_call","tool":"tool2","arguments":{"arg":2},"result":"res2"}}
+`;
+    const result = parseCodexOutput(output);
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools[0].tool).toBe("tool1");
+    expect(result.tools[1].tool).toBe("tool2");
+  });
+
+  it('should return null for empty input', () => {
+    expect(parseCodexOutput("")).toBeNull();
+  });
+
+  it('should handle invalid JSON gracefully', () => {
+    const output = `
+{"type":"valid"}
+INVALID_JSON
+{"type":"item.completed","item":{"type":"agent_message","text":"Still parses valid lines"}}
+`;
+    const result = parseCodexOutput(output);
+    expect(result.message).toBe("Still parses valid lines");
+  });
+});
+
+describe('parseClaudeOutput', () => {
+  it('should parse legacy JSON output', () => {
+    const output = JSON.stringify({
+      content: [{ type: 'text', text: 'Hello' }]
+    });
+    const result = parseClaudeOutput(output);
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'Hello' }]
+    });
+  });
+
+  it('should parse stream-json (NDJSON) output', () => {
+    const output = `
+{"type":"system","session_id":"test-claude-session"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Thinking..."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"call_1","name":"mcp__acm__run","input":{"prompt":"hi"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"call_1","content":"done"}]}}
+{"type":"result","result":"Final Answer","is_error":false}
+`;
+    const result = parseClaudeOutput(output);
+    
+    expect(result.message).toBe("Final Answer");
+    expect(result.session_id).toBe("test-claude-session");
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]).toEqual({
+      tool: "mcp__acm__run",
+      input: { prompt: "hi" },
+      output: "done"
+    });
+  });
+
+  it('should handle invalid NDJSON lines gracefully', () => {
+    const output = `
+{"type":"system"}
+INVALID_LINE
+{"type":"result","result":"Success"}
+`;
+    const result = parseClaudeOutput(output);
+    expect(result.message).toBe("Success");
+  });
+});

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -34,6 +34,13 @@ export function parseCodexOutput(stdout: string): any {
               input: parsed.item.arguments, // Map arguments to input to match common patterns
               output: parsed.item.result
             });
+          } else if (parsed.type === 'item.completed' && parsed.item?.type === 'command_execution') {
+            tools.push({
+              tool: 'command_execution',
+              input: { command: parsed.item.command },
+              output: parsed.item.aggregated_output,
+              exit_code: parsed.item.exit_code
+            });
           }
         } catch (e) {
           // Skip invalid JSON lines


### PR DESCRIPTION
### Summary
Enhanced `get_result` tool to support retrieving detailed execution history of **MCP tools**, **Skills**, and **Commands** executed by agents (Claude, Codex). This empowers the client (parent agent) to precisely understand 'what tools were used and what results were obtained' by sub-agents.

### Changes

#### 1. Added `verbose` option to `get_result` tool
- Calling `get_result(pid, verbose=true)` returns detailed info including a `tools` array (list of executed tools/skills) in addition to the standard result.
- Default behavior (`verbose=false`) remains concise.
- `wait` tool always operates with `verbose=false` to prevent log bloat.

#### 2. Enhanced Parsers (`src/parsers.ts`)
- **Codex**:
  - Supports parsing structured logs from `stderr`.
  - Extracts `mcp_tool_call` as well as `command_execution` history.
- **Claude**:
  - Supports parsing `stream-json` (NDJSON) format.
  - Implements logic to match and extract `tool_use` and `tool_result`.

#### 3. Updated Server Config (`src/server.ts`)
- Changed Claude CLI launch arguments to `--output-format stream-json --verbose` to capture detailed logs.

### Verification
- Verified via unit tests in `src/__tests__/parsers.test.ts`.
- Validated that `get_result` with `verbose: true` returns the `agentOutput.tools` array containing tool names, inputs, and outputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 詳細な実行情報とツール使用履歴を含む詳細モードを追加
  * 複数のAIモデル出力形式に対応した解析機能を改善し、より堅牢なエラーハンドリングを実装

* **テスト**
  * 出力解析処理の包括的なテストスイートを追加

* **その他**
  * 開発環境設定を更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->