### PR TITLE
fix: add --skip-git-repo-check flag for Codex CLI

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -156,7 +156,7 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
       args.push('--model', resolvedModel);
     }
 
-    args.push('--full-auto', '--json', prompt);
+    args.push('--skip-git-repo-check', '--full-auto', '--json', prompt);
 
   } else if (agent === 'gemini') {
     cliPath = options.cliPaths.gemini;


### PR DESCRIPTION
## Summary

Add `--skip-git-repo-check` flag to Codex CLI args in `buildCliCommand()`.

Without this flag, Codex refuses to execute when `workFolder` is not inside a git repository, failing with:
```
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

## Context

The three CLI branches handle non-interactive mode differently:

| Agent | Non-interactive flags | Git-agnostic |
|-------|----------------------|-------------|
| Claude | `--dangerously-skip-permissions` | Yes |
| Gemini | `-y` | Yes |
| Codex | `--full-auto` | **No** (requires git repo) |

This one-line fix aligns Codex with Claude and Gemini by adding `--skip-git-repo-check`.

## Change

```diff
- args.push('--full-auto', '--json', prompt);
+ args.push('--skip-git-repo-check', '--full-auto', '--json', prompt);
```

## Testing

Verified on Termux (aarch64, Android) with Codex `@openai/codex@0.104.0`:
- Before: `workFolder=/home/user` → exit code 1
- After: `workFolder=/home/user` → exit code 0, Codex responds correctly

Closes #12
