### PR TITLE
feat: gpt-5.4モデルを追加しcodex-ultraエイリアスを更新

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- Briefly describe what this PR does -->
+
+## Type of Change
+
+- [ ] feat: New feature
+- [ ] fix: Bug fix
+- [ ] refactor: Refactoring
+- [ ] docs: Documentation
+- [ ] test: Add or update tests
+- [ ] chore: Build, CI, dependencies, etc.
+
+## Changes
+
+<!-- List the main changes -->
+
+-
+
+## Test Plan
+
+- [ ] `npm run test:unit` passes
+- [ ] `npm run build` passes
+- [ ] Manual testing (if applicable)
+
+## Notes
+
+<!-- Any additional context for reviewers -->

--- a/.github/workflows/watch-codex-fork-pr.yml
+++ b/.github/workflows/watch-codex-fork-pr.yml
@@ -1,0 +1,98 @@
+name: Watch Codex Fork PR
+
+on:
+  schedule:
+    - cron: '17 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check upstream PR and notify issue
+        uses: actions/github-script@v7
+        env:
+          UPSTREAM_OWNER: openai
+          UPSTREAM_REPO: codex
+          UPSTREAM_PR_NUMBER: '13537'
+          TARGET_ISSUE_NUMBER: '7'
+          COMMENT_MARKER: '<!-- codex-fork-pr-13537-merged -->'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const upstreamOwner = process.env.UPSTREAM_OWNER;
+            const upstreamRepo = process.env.UPSTREAM_REPO;
+            const pull_number = Number(process.env.UPSTREAM_PR_NUMBER);
+            const issue_number = Number(process.env.TARGET_ISSUE_NUMBER);
+            const marker = process.env.COMMENT_MARKER;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: upstreamOwner,
+              repo: upstreamRepo,
+              pull_number,
+            });
+
+            core.summary
+              .addHeading('Upstream PR status')
+              .addTable([
+                [
+                  { data: 'Field', header: true },
+                  { data: 'Value', header: true },
+                ],
+                ['PR', `${upstreamOwner}/${upstreamRepo}#${pr.number}`],
+                ['Title', pr.title],
+                ['State', pr.state],
+                ['Merged', String(Boolean(pr.merged_at))],
+                ['Merged at', pr.merged_at ?? 'not merged'],
+                ['Updated at', pr.updated_at],
+                ['URL', pr.html_url],
+              ]);
+
+            if (!pr.merged_at) {
+              core.info(`PR #${pr.number} is not merged yet. No issue comment posted.`);
+              await core.summary.write();
+              return;
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) => comment.body?.includes(marker));
+            if (existingComment) {
+              core.info(`Issue #${issue_number} already has a merged notification comment.`);
+              await core.summary.addRaw(`Merged notification already exists: ${existingComment.html_url}\n`).write();
+              return;
+            }
+
+            const body = [
+              marker,
+              'upstream PR `openai/codex#13537` has been merged.',
+              '',
+              `- PR: ${pr.html_url}`,
+              `- Merged at: ${pr.merged_at}`,
+              '',
+              'This is the PR that adds non-interactive forking via `codex exec --fork <SESSION_ID> [PROMPT]`.',
+              'That means a new session ID can be issued when forking an existing session headlessly.',
+              '`resume` itself still continues the same session and does not issue a new session ID.',
+            ].join('\n');
+
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body,
+            });
+
+            core.info(`Posted merged notification to issue #${issue_number}: ${comment.html_url}`);
+            await core.summary
+              .addHeading('Issue notification')
+              .addRaw(`Posted merged notification: ${comment.html_url}\n`)
+              .write();

--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - 自動承認モードでGemini CLIを実行（`-y` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
-    - Codex (gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
+    - Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
     - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
 - PID追跡によるバックグラウンドプロセスの管理
 - ツールからの構造化された出力の解析と返却
@@ -133,7 +133,7 @@ Claude CLI、Codex CLI、またはGemini CLIを使用してプロンプトを実
 - **モデル (Models):**
     - **Ultra エイリアス:** `claude-ultra`, `codex-ultra` (自動的に high-reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-    - Codex: `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
+    - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 - `reasoning_effort` (string, 任意): Codex専用。`model_reasoning_effort` を設定します（許容値: "low", "medium", "high", "xhigh"）。
 - `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。対応モデル: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview。

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Run Claude CLI with all permissions bypassed (using `--dangerously-skip-permissions`)
 - Execute Codex CLI with automatic approval mode (using `--full-auto`)
 - Execute Gemini CLI with automatic approval mode (using `-y`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), and Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), and Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -132,7 +132,7 @@ Executes a prompt using Claude CLI, Codex CLI, or Gemini CLI. The appropriate CL
 **Models:**
 - **Ultra Aliases:** `claude-ultra`, `codex-ultra` (defaults to high-reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-- Codex: `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
+- Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 - `reasoning_effort` (string, optional): Codex only. Sets `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh").
 - `session_id` (string, optional): Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview.

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -117,7 +117,7 @@ src/
 
 ```
 claude-ultra  → opus
-codex-ultra   → gpt-5.3-codex (+ reasoning_effort: high)
+codex-ultra   → gpt-5.4 (+ reasoning_effort: high)
 gemini-ultra  → gemini-3.1-pro-preview
 ```
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -99,7 +99,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 | Provider | Models |
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku` |
-| Codex | `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5` |
+| Codex | `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5` |
 | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -36,8 +36,8 @@ describe('cli-builder', () => {
       expect(resolveModelAlias('claude-ultra')).toBe('opus');
     });
 
-    it('should resolve codex-ultra to gpt-5.3-codex', () => {
-      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.3-codex');
+    it('should resolve codex-ultra to gpt-5.4', () => {
+      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.4');
     });
 
     it('should resolve gemini-ultra to gemini-3.1-pro-preview', () => {
@@ -280,7 +280,7 @@ describe('cli-builder', () => {
         });
 
         expect(cmd.agent).toBe('codex');
-        expect(cmd.resolvedModel).toBe('gpt-5.3-codex');
+        expect(cmd.resolvedModel).toBe('gpt-5.4');
         expect(cmd.args).toContain('-c');
         expect(cmd.args).toContain('model_reasoning_effort=xhigh');
       });

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -4,7 +4,7 @@ import { resolve as pathResolve, isAbsolute } from 'node:path';
 // Model alias mappings for user-friendly model names
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
-  'codex-ultra': 'gpt-5.3-codex',
+  'codex-ultra': 'gpt-5.4',
   'gemini-ultra': 'gemini-3.1-pro-preview'
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -162,7 +162,7 @@ export class ClaudeCodeServer {
 **IMPORTANT**: This tool now returns immediately with a PID. Use other tools to check status and get results.
 
 **Supported models**:
-"claude-ultra", "codex-ultra", "gemini-ultra", "sonnet", "sonnet[1m]", "opus", "opusplan", "haiku", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini", "gpt-5.1-codex-max", "gpt-5.2", "gpt-5.1", "gpt-5.1-codex", "gpt-5-codex", "gpt-5-codex-mini", "gpt-5", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview"
+"claude-ultra", "codex-ultra", "gemini-ultra", "sonnet", "sonnet[1m]", "opus", "opusplan", "haiku", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini", "gpt-5.1-codex-max", "gpt-5.2", "gpt-5.1", "gpt-5.1-codex", "gpt-5-codex", "gpt-5-codex-mini", "gpt-5", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview"
 
 **Prompt input**: You must provide EITHER prompt (string) OR prompt_file (file path), but not both.
 
@@ -190,7 +190,7 @@ export class ClaudeCodeServer {
               },
               model: {
                 type: 'string',
-                description: 'The model to use. Aliases: "claude-ultra", "codex-ultra" (auto high-reasoning), "gemini-ultra". Standard: "sonnet", "sonnet[1m]", "opus", "opusplan", "haiku", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini", "gpt-5.1", "gemini-2.5-pro", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", etc.',
+                description: 'The model to use. Aliases: "claude-ultra", "codex-ultra" (auto high-reasoning), "gemini-ultra". Standard: "sonnet", "sonnet[1m]", "opus", "opusplan", "haiku", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini", "gpt-5.1", "gemini-2.5-pro", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", etc.',
               },
               reasoning_effort: {
                 type: 'string',


### PR DESCRIPTION
## Summary

`gpt-5.4` モデルを新規追加し、`codex-ultra` エイリアスを `gpt-5.3-codex` から `gpt-5.4` に更新する。また、GitHub PR テンプレートを追加する。

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Refactoring
- [x] docs: Documentation
- [ ] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- [x] `src/cli-builder.ts`: `codex-ultra` エイリアスを `gpt-5.3-codex` → `gpt-5.4` に変更
- [x] `src/server.ts`: サポートモデル一覧と説明文に `gpt-5.4` を追加
- [x] `src/__tests__/cli-builder.test.ts`: `codex-ultra` エイリアスのテストを `gpt-5.4` に更新
- [x] `README.md` / `README.ja.md`: Codex モデル一覧に `gpt-5.4` を追記
- [x] `docs/concept.md` / `docs/prd.md`: `codex-ultra` → `gpt-5.4` の記述を更新
- [x] `.github/pull_request_template.md`: GitHub PR テンプレートを新規追加

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

<!-- Any additional context for reviewers -->
