### PR TITLE
feat: ClaudeモデルへのReasoning Effort（--effort）サポートを追加

### DIFF
--- a/.github/workflows/watch-session-prs.yml
+++ b/.github/workflows/watch-session-prs.yml
@@ -21,6 +21,8 @@ jobs:
           UPSTREAM_PR_NUMBER: '13537'
           TARGET_ISSUE_NUMBER: '7'
           COMMENT_MARKER: '<!-- codex-fork-pr-13537-status -->'
+          READY_LABEL: '[ready]'
+          STOP_LABEL: '[stop]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -29,8 +31,41 @@ jobs:
             const pull_number = Number(process.env.UPSTREAM_PR_NUMBER);
             const issue_number = Number(process.env.TARGET_ISSUE_NUMBER);
             const marker = process.env.COMMENT_MARKER;
+            const readyLabel = process.env.READY_LABEL;
+            const stopLabel = process.env.STOP_LABEL;
 
             const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number });
+            const desiredLabel = pr.merged_at ? readyLabel : stopLabel;
+            const staleLabel = pr.merged_at ? stopLabel : readyLabel;
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            if (!issue.labels.some((label) => label.name === desiredLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: [desiredLabel],
+              });
+              core.info(`Added label ${desiredLabel} to issue #${issue_number}.`);
+            }
+
+            if (issue.labels.some((label) => label.name === staleLabel)) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: staleLabel,
+                });
+                core.info(`Removed label ${staleLabel} from issue #${issue_number}.`);
+              } catch (error) {
+                core.warning(`Failed to remove label ${staleLabel}: ${error.message}`);
+              }
+            }
 
             core.summary
               .addHeading('Codex PR status')
@@ -110,6 +145,9 @@ jobs:
           TARGET_ISSUE_NUMBER: '16'
           COMMENT_MARKER: '<!-- gemini-session-pr-status -->'
           WATCH_PR_NUMBERS: '17921,19629,19994'
+          READY_PR_NUMBERS: '17921,19629'
+          READY_LABEL: '[ready]'
+          STOP_LABEL: '[stop]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -118,6 +156,9 @@ jobs:
             const issue_number = Number(process.env.TARGET_ISSUE_NUMBER);
             const marker = process.env.COMMENT_MARKER;
             const pullNumbers = process.env.WATCH_PR_NUMBERS.split(',').map((value) => Number(value.trim()));
+            const readyPullNumbers = process.env.READY_PR_NUMBERS.split(',').map((value) => Number(value.trim()));
+            const readyLabel = process.env.READY_LABEL;
+            const stopLabel = process.env.STOP_LABEL;
 
             const pulls = await Promise.all(
               pullNumbers.map(async (pull_number) => {
@@ -125,6 +166,39 @@ jobs:
                 return pr;
               }),
             );
+            const isReady = pulls.some((pr) => readyPullNumbers.includes(pr.number) && Boolean(pr.merged_at));
+            const desiredLabel = isReady ? readyLabel : stopLabel;
+            const staleLabel = isReady ? stopLabel : readyLabel;
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            if (!issue.labels.some((label) => label.name === desiredLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                labels: [desiredLabel],
+              });
+              core.info(`Added label ${desiredLabel} to issue #${issue_number}.`);
+            }
+
+            if (issue.labels.some((label) => label.name === staleLabel)) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  name: staleLabel,
+                });
+                core.info(`Removed label ${staleLabel} from issue #${issue_number}.`);
+              } catch (error) {
+                core.warning(`Failed to remove label ${staleLabel}: ${error.message}`);
+              }
+            }
 
             const lines = pulls.flatMap((pr) => [
               `- \`${owner}/${repo}#${pr.number}\` ${pr.title}`,

--- a/README.ja.md
+++ b/README.ja.md
@@ -131,11 +131,11 @@ Claude CLI、Codex CLI、またはGemini CLIを使用してプロンプトを実
 - `prompt_file` (string, 任意): プロンプトを含むファイルへのパス。`prompt` または `prompt_file` のいずれかが必須です。絶対パス、または `workFolder` からの相対パスが指定可能です。
 - `workFolder` (string, 必須): CLIを実行する作業ディレクトリ。絶対パスである必要があります。
 - **モデル (Models):**
-    - **Ultra エイリアス:** `claude-ultra`, `codex-ultra` (自動的に high-reasoning に設定), `gemini-ultra`
+    - **Ultra エイリアス:** `claude-ultra` (自動的に high effort に設定), `codex-ultra` (自動的に xhigh reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
     - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
-- `reasoning_effort` (string, 任意): Codex専用。`model_reasoning_effort` を設定します（許容値: "low", "medium", "high", "xhigh"）。
+- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。
 - `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。対応モデル: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview。
 
 ### `wait`

--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ Executes a prompt using Claude CLI, Codex CLI, or Gemini CLI. The appropriate CL
 - `prompt_file` (string, optional): Path to a file containing the prompt. Either `prompt` or `prompt_file` is required. Can be absolute path or relative to `workFolder`.
 - `workFolder` (string, required): The working directory for the CLI execution. Must be an absolute path.
 **Models:**
-- **Ultra Aliases:** `claude-ultra`, `codex-ultra` (defaults to high-reasoning), `gemini-ultra`
+- **Ultra Aliases:** `claude-ultra` (defaults to high effort), `codex-ultra` (defaults to xhigh reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
 - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
-- `reasoning_effort` (string, optional): Codex only. Sets `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh").
+- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh").
 - `session_id` (string, optional): Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview.
 
 ### `wait`

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -76,6 +76,8 @@ describe('cli-builder', () => {
       expect(getReasoningEffort('gpt-5.2', 'medium')).toBe('medium');
       expect(getReasoningEffort('gpt-5.2', 'high')).toBe('high');
       expect(getReasoningEffort('gpt-5.2', 'xhigh')).toBe('xhigh');
+      expect(getReasoningEffort('sonnet', 'high')).toBe('high');
+      expect(getReasoningEffort('', 'low')).toBe('low');
     });
 
     it('should throw for invalid reasoning effort value', () => {
@@ -84,9 +86,15 @@ describe('cli-builder', () => {
       );
     });
 
-    it('should throw for non-codex models', () => {
-      expect(() => getReasoningEffort('sonnet', 'high')).toThrow(
-        'reasoning_effort is only supported for Codex models (gpt-*).'
+    it('should reject xhigh for claude models', () => {
+      expect(() => getReasoningEffort('sonnet', 'xhigh')).toThrow(
+        'Claude reasoning_effort supports only low, medium, high.'
+      );
+    });
+
+    it('should throw for unsupported model families', () => {
+      expect(() => getReasoningEffort('gemini-2.5-pro', 'high')).toThrow(
+        'reasoning_effort is only supported for Claude and Codex models.'
       );
     });
   });
@@ -223,6 +231,57 @@ describe('cli-builder', () => {
         expect(cmd.agent).toBe('claude');
         expect(cmd.resolvedModel).toBe('opus');
         expect(cmd.args).toContain('opus');
+      });
+
+      it('should resolve claude-ultra and default to high effort', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'claude-ultra',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toContain('--effort');
+        expect(cmd.args).toContain('high');
+      });
+
+      it('should build claude command with reasoning_effort using --effort', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'sonnet',
+          reasoning_effort: 'medium',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toContain('--effort');
+        expect(cmd.args).toContain('medium');
+      });
+
+      it('should reject xhigh reasoning_effort for claude', () => {
+        expect(() =>
+          buildCliCommand({
+            prompt: 'test',
+            workFolder: '/tmp',
+            model: 'sonnet',
+            reasoning_effort: 'xhigh',
+            cliPaths: DEFAULT_CLI_PATHS,
+          })
+        ).toThrow('Claude reasoning_effort supports only low, medium, high.');
+      });
+
+      it('should allow overriding reasoning_effort for claude-ultra', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'claude-ultra',
+          reasoning_effort: 'low',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toContain('--effort');
+        expect(cmd.args).toContain('low');
+        expect(cmd.args).not.toContain('high');
       });
     });
 

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -301,7 +301,7 @@ describe('Argument Validation Tests', () => {
       ).rejects.toThrow(/reasoning_effort/i);
     });
 
-    it('should reject reasoning_effort for non-codex models', async () => {
+    it('should reject reasoning_effort for unsupported model families', async () => {
       await setupServer();
       const handler = handlers.get('callTool')!;
 
@@ -312,7 +312,7 @@ describe('Argument Validation Tests', () => {
             arguments: {
               prompt: 'test',
               workFolder: '/tmp',
-              model: 'sonnet',
+              model: 'gemini-2.5-pro',
               reasoning_effort: 'low'
             }
           }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -9,6 +9,17 @@ export const MODEL_ALIASES: Record<string, string> = {
 };
 
 export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
+const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high']);
+
+function getAgentForModel(model: string): 'codex' | 'claude' | 'gemini' {
+  if (model.startsWith('gpt-')) {
+    return 'codex';
+  }
+  if (model.startsWith('gemini')) {
+    return 'gemini';
+  }
+  return 'claude';
+}
 
 /**
  * Resolves model aliases to their full model names
@@ -38,9 +49,15 @@ export function getReasoningEffort(model: string, rawValue: unknown): string {
       `Invalid reasoning_effort: ${rawValue}. Allowed values: low, medium, high, xhigh.`
     );
   }
-  if (!model.startsWith('gpt-')) {
+  const agent = getAgentForModel(model);
+  if (agent === 'gemini') {
     throw new Error(
-      'reasoning_effort is only supported for Codex models (gpt-*).'
+      'reasoning_effort is only supported for Claude and Codex models.'
+    );
+  }
+  if (agent === 'claude' && !CLAUDE_REASONING_EFFORTS.has(normalized)) {
+    throw new Error(
+      'Claude reasoning_effort supports only low, medium, high.'
     );
   }
   return normalized;
@@ -117,24 +134,19 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
   // Resolve model
   const rawModel = options.model || '';
   const resolvedModel = resolveModelAlias(rawModel);
+  const agent = getAgentForModel(resolvedModel);
 
-  // Special handling for codex-ultra: default to high reasoning effort if not specified
+  // Special handling for ultra aliases: default to higher reasoning if not specified
   let reasoningEffortArg: string | undefined = options.reasoning_effort;
-  if (rawModel === 'codex-ultra' && !reasoningEffortArg) {
-    reasoningEffortArg = 'xhigh';
+  if (!reasoningEffortArg) {
+    if (rawModel === 'codex-ultra') {
+      reasoningEffortArg = 'xhigh';
+    } else if (rawModel === 'claude-ultra') {
+      reasoningEffortArg = 'high';
+    }
   }
 
   const reasoningEffort = getReasoningEffort(resolvedModel, reasoningEffortArg);
-
-  // Determine agent
-  let agent: 'codex' | 'claude' | 'gemini';
-  if (resolvedModel.startsWith('gpt-')) {
-    agent = 'codex';
-  } else if (resolvedModel.startsWith('gemini')) {
-    agent = 'gemini';
-  } else {
-    agent = 'claude';
-  }
 
   // Build CLI path and args
   let cliPath: string;
@@ -178,6 +190,10 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
 
     if (options.session_id && typeof options.session_id === 'string') {
       args.push('-r', options.session_id, '--fork-session');
+    }
+
+    if (reasoningEffort) {
+      args.push('--effort', reasoningEffort);
     }
 
     args.push('-p', prompt);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,7 +40,7 @@ Options:
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt
   --session_id         Session ID to resume
-  --reasoning_effort   Codex only: low, medium, high, xhigh
+  --reasoning_effort   Claude/Codex: Claude=low|medium|high, Codex=low|medium|high|xhigh
   --help               Show this help message
 
 Raw CLI output goes to stdout. Use cli.run.parse to parse the output:

--- a/src/server.ts
+++ b/src/server.ts
@@ -190,11 +190,11 @@ export class ClaudeCodeServer {
               },
               model: {
                 type: 'string',
-                description: 'The model to use. Aliases: "claude-ultra", "codex-ultra" (auto high-reasoning), "gemini-ultra". Standard: "sonnet", "sonnet[1m]", "opus", "opusplan", "haiku", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini", "gpt-5.1", "gemini-2.5-pro", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", etc.',
+                description: 'The model to use. Aliases: "claude-ultra" (auto high effort), "codex-ultra" (auto xhigh reasoning), "gemini-ultra". Standard: "sonnet", "sonnet[1m]", "opus", "opusplan", "haiku", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.1-codex-mini", "gpt-5.1", "gemini-2.5-pro", "gemini-3.1-pro-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", etc.',
               },
               reasoning_effort: {
                 type: 'string',
-                description: 'Codex only. Sets model_reasoning_effort. Allowed: "low", "medium", "high", "xhigh".',
+                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh".',
               },
               session_id: {
                 type: 'string',


### PR DESCRIPTION
## Summary

ClaudeモデルへのReasoning Effort（`--effort`）サポートを追加し、CI PR監視ワークフローをセッション関連PR対応の統合版に置き換える。

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Refactoring
- [ ] docs: Documentation
- [ ] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- `reasoning_effort` パラメータをClaudeモデルに対応させ、`--effort` フラグで渡すように変更（許容値: `low`, `medium`, `high`）
- `claude-ultra` エイリアスがデフォルトで `high` effort を設定するように変更（`codex-ultra` は引き続き `xhigh` reasoning）
- `getAgentForModel()` ヘルパー関数を追加し、モデル判定ロジックを共通化
- `xhigh` をClaudeモデルで指定した場合にエラーをスローするよう制御を追加
- CI: `watch-codex-fork-pr.yml` を削除し、CodexとGemini両方のセッション関連PRを監視する統合ワークフロー `watch-session-prs.yml` に置き換え
- README.md / README.ja.md のモデル説明・パラメータ説明を更新

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

<!-- テスト追加内容 -->
- `getReasoningEffort()`: Claudeモデルへの対応、`xhigh`拒否、Gemini拒否のケースを追加
- `buildCliCommand()`: `claude-ultra` のデフォルト effort、`sonnet` への `reasoning_effort` 指定、`xhigh` 拒否、`claude-ultra` の effort オーバーライドのテストを追加
- `validation.test.ts`: unsupported model family（Gemini）での拒否テストに変更

Closes #17