### PR TITLE
feat: Forge CLIを新しいAIバックエンドとして追加

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,22 +43,43 @@ jobs:
       - name: Verify provenance attestations
         run: npm audit signatures
 
+      - name: Capture version before release
+        id: release_before
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
+      - name: Capture version after release
+        id: release_after
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Detect whether a release was published
+        id: release_status
+        run: |
+          if [ "${{ steps.release_before.outputs.version }}" != "${{ steps.release_after.outputs.version }}" ]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install mcp-publisher
+        if: steps.release_status.outputs.published == 'true'
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Authenticate to MCP Registry
+        if: steps.release_status.outputs.published == 'true'
         run: ./mcp-publisher login github-oidc
 
       - name: Set version in server.json
+        if: steps.release_status.outputs.published == 'true'
         run: |
           VERSION=$(node -p "require('./package.json').version")
           jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
 
       - name: Publish to MCP Registry
+        if: steps.release_status.outputs.published == 'true'
         run: ./mcp-publisher publish

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 
 > **📦 パッケージ移行のお知らせ**: 本パッケージは旧名 `@mkxultra/claude-code-mcp` から `ai-cli-mcp` に名称変更されました。これは、複数のAI CLIツールのサポート拡大を反映したものです。
 
-AI CLIツール（Claude, Codex, Gemini）をバックグラウンドプロセスとして実行し、権限処理を自動化するMCP（Model Context Protocol）サーバーです。
+AI CLIツール（Claude, Codex, Gemini, Forge）をバックグラウンドプロセスとして実行し、権限処理を自動化するMCP（Model Context Protocol）サーバーです。
 
 Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦戦していることに気づいたことはありませんか？このサーバーは、強力な統合 `run` ツールを提供し、複数のAIエージェントを活用してコーディングタスクをより効果的に処理できるようにします。
 
@@ -20,10 +20,12 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - すべての権限確認をスキップしてClaude CLIを実行（`--dangerously-skip-permissions` を使用）
 - 自動承認モードでCodex CLIを実行（`--full-auto` を使用）
 - 自動承認モードでGemini CLIを実行（`-y` を使用）
+- Forge CLI を非対話モードで実行（`forge -C <workFolder> -p <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
     - Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
     - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
+    - Forge (`forge`)
 - PID追跡によるバックグラウンドプロセスの管理
 - ツールからの構造化された出力の解析と返却
 
@@ -55,7 +57,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 
 - **真の非同期マルチタスク**: エージェントの実行はバックグラウンドで行われ、即座に制御が戻ります。呼び出し元のAIは実行完了を待つことなく、並行して次のタスクの実行や別のエージェントの呼び出しを行うことができます。
 - **CLI in CLI (Agent in Agent) の実現**: MCPをサポートするあらゆるIDEやCLIから、Claude CodeやCodexといった強力なCLIツールを直接呼び出せます。ホスト環境の制限を超えた、より広範で複雑なシステム操作や自動化が可能になります。
-- **モデル・プロバイダの制約からの解放**: 特定のエコシステムに縛られることなく、Claude、Codex (GPT)、Geminiの中から、タスクに最適な「最強のモデル」や「コスト効率の良いモデル」を自由に選択・組み合わせて利用できます。
+- **モデル・プロバイダの制約からの解放**: 特定のエコシステムに縛られることなく、Claude、Codex (GPT)、Gemini、Forgeの中から、タスクに最適な「最強のモデル」や「コスト効率の良いモデル」を自由に選択・組み合わせて利用できます。
 
 ## 前提条件
 
@@ -64,6 +66,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - **Claude Code**: `claude doctor` が通り、`--dangerously-skip-permissions` での実行が承認済み（一度手動で実行してログイン・承認済み）であること。
 - **Codex CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
 - **Gemini CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
+- **Forge CLI**（オプション）: インストール済みで、初期設定が完了していること。
 
 ## インストールと使い方
 
@@ -222,7 +225,7 @@ detached 実行された `ai-cli` の自然終了 exit code は、まだ永続�
 
 ### `run`
 
-Claude CLI、Codex CLI、またはGemini CLIを使用してプロンプトを実行します。モデル名に基づいて適切なCLIが自動的に選択されます。
+Claude CLI、Codex CLI、Gemini CLI、または Forge CLI を使用してプロンプトを実行します。モデル名に基づいて適切なCLIが自動的に選択されます。
 
 **引数:**
 - `prompt` (string, 任意): AIエージェントに送信するプロンプト。`prompt` または `prompt_file` のいずれかが必須です。
@@ -233,8 +236,9 @@ Claude CLI、Codex CLI、またはGemini CLIを使用してプロンプトを実
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
     - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
-- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。
-- `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。対応モデル: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview。
+    - Forge: `forge`
+- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。Forge では `reasoning_effort` はサポートしません。
+- `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。対応モデル: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview, forge。
 
 ### `wait`
 
@@ -296,6 +300,7 @@ npm run test:e2e
 - `CLAUDE_CLI_NAME`: Claude CLIのバイナリ名または絶対パスを上書き（デフォルト: `claude`）
 - `CODEX_CLI_NAME`: Codex CLIのバイナリ名または絶対パスを上書き（デフォルト: `codex`）
 - `GEMINI_CLI_NAME`: Gemini CLIのバイナリ名または絶対パスを上書き（デフォルト: `gemini`）
+- `FORGE_CLI_NAME`: Forge CLIのバイナリ名または絶対パスを上書き（デフォルト: `forge`）
 - `MCP_CLAUDE_DEBUG`: デバッグログを有効化（`true` に設定すると詳細な出力が表示されます）
 
 **CLI名の指定方法:**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **📦 Package Migration Notice**: This package was formerly `@mkxultra/claude-code-mcp` and has been renamed to `ai-cli-mcp` to reflect its expanded support for multiple AI CLI tools.
 
-An MCP (Model Context Protocol) server that allows running AI CLI tools (Claude, Codex, and Gemini) in background processes with automatic permission handling.
+An MCP (Model Context Protocol) server that allows running AI CLI tools (Claude, Codex, Gemini, and Forge) in background processes with automatic permission handling.
 
 Did you notice that Cursor sometimes struggles with complex, multi-step edits or operations? This server, with its powerful unified `run` tool, enables multiple AI agents to handle your coding tasks more effectively.
 
@@ -22,7 +22,8 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Run Claude CLI with all permissions bypassed (using `--dangerously-skip-permissions`)
 - Execute Codex CLI with automatic approval mode (using `--full-auto`)
 - Execute Gemini CLI with automatic approval mode (using `-y`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), and Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
+- Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), and Forge (`forge`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -54,7 +55,7 @@ You can reuse heavy context (like large codebases) using session IDs to save cos
 
 - **True Async Multitasking**: Agent execution happens in the background, returning control immediately. The calling AI can proceed with the next task or invoke another agent without waiting for completion.
 - **CLI in CLI (Agent in Agent)**: Directly invoke powerful CLI tools like Claude Code or Codex from any MCP-supported IDE or CLI. This enables broader, more complex system operations and automation beyond host environment limitations.
-- **Freedom from Model/Provider Constraints**: Freely select and combine the "strongest" or "most cost-effective" models from Claude, Codex (GPT), and Gemini without being tied to a specific ecosystem.
+- **Freedom from Model/Provider Constraints**: Freely select and combine the "strongest" or "most cost-effective" models from Claude, Codex (GPT), Gemini, and Forge without being tied to a specific ecosystem.
 
 ## Prerequisites
 
@@ -63,6 +64,7 @@ The only prerequisite is that the AI CLI tools you want to use are locally insta
 - **Claude Code**: `claude doctor` passes, and execution with `--dangerously-skip-permissions` is approved (you must run it manually once to login and accept terms).
 - **Codex CLI** (Optional): Installed and initial setup (login etc.) completed.
 - **Gemini CLI** (Optional): Installed and initial setup (login etc.) completed.
+- **Forge CLI** (Optional): Installed and initial setup completed.
 
 ## Installation & Usage
 
@@ -221,7 +223,7 @@ This server exposes the following tools:
 
 ### `run`
 
-Executes a prompt using Claude CLI, Codex CLI, or Gemini CLI. The appropriate CLI is automatically selected based on the model name.
+Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, or Forge CLI. The appropriate CLI is automatically selected based on the model name.
 
 **Arguments:**
 - `prompt` (string, optional): The prompt to send to the AI agent. Either `prompt` or `prompt_file` is required.
@@ -232,8 +234,9 @@ Executes a prompt using Claude CLI, Codex CLI, or Gemini CLI. The appropriate CL
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
 - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
-- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh").
-- `session_id` (string, optional): Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview.
+- Forge: `forge`
+- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh"). Forge does not support `reasoning_effort`.
+- `session_id` (string, optional): Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview, forge.
 
 ### `wait`
 
@@ -281,6 +284,7 @@ Normally not required, but useful for customizing CLI paths or debugging.
 - `CLAUDE_CLI_NAME`: Override the Claude CLI binary name or provide an absolute path (default: `claude`)
 - `CODEX_CLI_NAME`: Override the Codex CLI binary name or provide an absolute path (default: `codex`)
 - `GEMINI_CLI_NAME`: Override the Gemini CLI binary name or provide an absolute path (default: `gemini`)
+- `FORGE_CLI_NAME`: Override the Forge CLI binary name or provide an absolute path (default: `forge`)
 - `MCP_CLAUDE_DEBUG`: Enable debug logging (set to `true` for verbose output)
 
 **CLI Name Specification:**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-cli-mcp",
   "version": "2.12.0",
   "mcpName": "io.github.mkXultra/ai-cli-mcp",
-  "description": "MCP server for AI CLI tools (Claude, Codex, and Gemini) with background process management",
+  "description": "MCP server for AI CLI tools (Claude, Codex, Gemini, and Forge) with background process management",
   "author": "mkXultra",
   "license": "MIT",
   "main": "dist/server.js",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mkXultra/ai-cli-mcp",
-  "description": "MCP server for AI CLI tools (Claude, Codex, and Gemini) with background process management",
+  "description": "MCP server for AI CLI tools (Claude, Codex, Gemini, and Forge) with background process management",
   "repository": {
     "url": "https://github.com/mkXultra/ai-cli-mcp",
     "source": "github"

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -222,6 +222,7 @@ describe('ai-cli app', () => {
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"aliases"'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"claude-ultra"'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"gpt-5.4"'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"forge"'));
     expect(stderr).not.toHaveBeenCalled();
   });
 
@@ -244,6 +245,12 @@ describe('ai-cli app', () => {
       gemini: {
         configuredCommand: 'gemini',
         resolvedPath: '/tmp/bin/gemini',
+        available: true,
+        lookup: 'path',
+      },
+      forge: {
+        configuredCommand: 'forge',
+        resolvedPath: '/tmp/bin/forge',
         available: true,
         lookup: 'path',
       },
@@ -280,6 +287,7 @@ describe('ai-cli app', () => {
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('claude-ultra'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.2-codex'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-2.5-pro'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('forge'));
     expect(stderr).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/cli-bin-smoke.test.ts
+++ b/src/__tests__/cli-bin-smoke.test.ts
@@ -30,6 +30,7 @@ describe('ai-cli entrypoint smoke', () => {
     writeExecutable(fakeBinDir, 'claude');
     writeExecutable(fakeBinDir, 'codex');
     writeExecutable(fakeBinDir, 'gemini');
+    writeExecutable(fakeBinDir, 'forge');
 
     const output = execFileSync(
       'node',
@@ -43,6 +44,7 @@ describe('ai-cli entrypoint smoke', () => {
           CLAUDE_CLI_NAME: 'claude',
           CODEX_CLI_NAME: 'codex',
           GEMINI_CLI_NAME: 'gemini',
+          FORGE_CLI_NAME: 'forge',
         },
       }
     );
@@ -50,6 +52,7 @@ describe('ai-cli entrypoint smoke', () => {
     expect(output).toContain('"claude"');
     expect(output).toContain('"codex"');
     expect(output).toContain('"gemini"');
+    expect(output).toContain('"forge"');
     expect(output).toContain('"available": true');
   });
 
@@ -67,5 +70,6 @@ describe('ai-cli entrypoint smoke', () => {
     expect(output).toContain('Usage: ai-cli run --cwd <path> [options]');
     expect(output).toContain('--model <model>');
     expect(output).toContain('claude-ultra');
+    expect(output).toContain('forge');
   });
 });

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -22,6 +22,7 @@ const DEFAULT_CLI_PATHS = {
   claude: '/usr/bin/claude',
   codex: '/usr/bin/codex',
   gemini: '/usr/bin/gemini',
+  forge: '/usr/bin/forge',
 };
 
 describe('cli-builder', () => {
@@ -95,6 +96,12 @@ describe('cli-builder', () => {
     it('should throw for unsupported model families', () => {
       expect(() => getReasoningEffort('gemini-2.5-pro', 'high')).toThrow(
         'reasoning_effort is only supported for Claude and Codex models.'
+      );
+    });
+
+    it('should reject reasoning_effort for forge explicitly', () => {
+      expect(() => getReasoningEffort('forge', 'high')).toThrow(
+        'reasoning_effort is not supported for forge.'
       );
     });
   });
@@ -399,6 +406,46 @@ describe('cli-builder', () => {
 
         expect(cmd.agent).toBe('gemini');
         expect(cmd.resolvedModel).toBe('gemini-3.1-pro-preview');
+      });
+    });
+
+    describe('forge agent', () => {
+      it('should build forge command without model flags', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'forge',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.agent).toBe('forge');
+        expect(cmd.cliPath).toBe('/usr/bin/forge');
+        expect(cmd.resolvedModel).toBe('forge');
+        expect(cmd.args).toEqual(['-C', '/tmp', '-p', 'test']);
+      });
+
+      it('should map session_id to --conversation-id for forge', () => {
+        const cmd = buildCliCommand({
+          prompt: 'test',
+          workFolder: '/tmp',
+          model: 'forge',
+          session_id: 'forge-conv-123',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toEqual(['-C', '/tmp', '--conversation-id', 'forge-conv-123', '-p', 'test']);
+      });
+
+      it('should reject reasoning_effort for forge in command building', () => {
+        expect(() =>
+          buildCliCommand({
+            prompt: 'test',
+            workFolder: '/tmp',
+            model: 'forge',
+            reasoning_effort: 'high',
+            cliPaths: DEFAULT_CLI_PATHS,
+          })
+        ).toThrow('reasoning_effort is not supported for forge.');
       });
     });
   });

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -65,6 +65,7 @@ describe('CliProcessService', () => {
         claude: scriptPath,
         codex: scriptPath,
         gemini: scriptPath,
+        forge: scriptPath,
       },
     });
 
@@ -114,6 +115,7 @@ describe('CliProcessService', () => {
         claude: scriptPath,
         codex: scriptPath,
         gemini: scriptPath,
+        forge: scriptPath,
       },
     });
 
@@ -152,6 +154,7 @@ describe('CliProcessService', () => {
         claude: '/bin/sh',
         codex: '/bin/sh',
         gemini: '/bin/sh',
+        forge: '/bin/sh',
       },
     });
 
@@ -254,6 +257,7 @@ describe('CliProcessService', () => {
         claude: '/bin/sh',
         codex: '/bin/sh',
         gemini: '/bin/sh',
+        forge: '/bin/sh',
       },
     });
 
@@ -274,5 +278,57 @@ describe('CliProcessService', () => {
     expect(existsSync(completedDir)).toBe(false);
     expect(existsSync(failedDir)).toBe(false);
     killSpy.mockRestore();
+  });
+
+  it('parses forge output from detached process logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'forge-project');
+    mkdirSync(workFolder, { recursive: true });
+    const pid = 54321;
+    const processDir = join(stateDir, 'cwds', encodeCwd(realpathSync(workFolder)), String(pid));
+    mkdirSync(processDir, { recursive: true });
+
+    writeFileSync(
+      join(processDir, 'stdout.log'),
+      `● [21:09:01] Initialize forge-conv-1
+Forge assistant reply
+● [21:09:08] Finished forge-conv-1
+`
+    );
+    writeFileSync(join(processDir, 'stderr.log'), '');
+    writeFileSync(
+      join(processDir, 'meta.json'),
+      JSON.stringify({
+        pid,
+        prompt: 'hello forge',
+        workFolder,
+        model: 'forge',
+        toolType: 'forge',
+        startTime: new Date().toISOString(),
+        stdoutPath: join(processDir, 'stdout.log'),
+        stderrPath: join(processDir, 'stderr.log'),
+        status: 'completed',
+      })
+    );
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: '/bin/sh',
+        codex: '/bin/sh',
+        gemini: '/bin/sh',
+        forge: '/bin/sh',
+      },
+    });
+
+    const result = await service.getProcessResult(pid, false);
+    expect(result.agent).toBe('forge');
+    expect(result.session_id).toBe('forge-conv-1');
+    expect(result.agentOutput).toEqual({
+      message: 'Forge assistant reply',
+      session_id: 'forge-conv-1',
+    });
   });
 });

--- a/src/__tests__/cli-utils.test.ts
+++ b/src/__tests__/cli-utils.test.ts
@@ -19,6 +19,7 @@ describe('cli-utils doctor status', () => {
     delete process.env.CLAUDE_CLI_NAME;
     delete process.env.CODEX_CLI_NAME;
     delete process.env.GEMINI_CLI_NAME;
+    delete process.env.FORGE_CLI_NAME;
     process.env.PATH = '/mock/bin:/usr/bin';
   });
 
@@ -44,6 +45,12 @@ describe('cli-utils doctor status', () => {
       available: true,
       lookup: 'path',
     });
+    expect(status.forge).toEqual({
+      configuredCommand: 'forge',
+      resolvedPath: null,
+      available: false,
+      lookup: 'path',
+    });
   });
 
   it('does not mark non-executable PATH entries as available', async () => {
@@ -56,6 +63,12 @@ describe('cli-utils doctor status', () => {
 
     expect(status.claude).toEqual({
       configuredCommand: 'claude',
+      resolvedPath: null,
+      available: false,
+      lookup: 'path',
+    });
+    expect(status.forge).toEqual({
+      configuredCommand: 'forge',
       resolvedPath: null,
       available: false,
       lookup: 'path',
@@ -128,5 +141,26 @@ describe('cli-utils doctor status', () => {
       available: true,
       lookup: 'env',
     });
+  });
+
+  it('supports forge lookup via FORGE_CLI_NAME', async () => {
+    process.env.FORGE_CLI_NAME = 'forge-custom';
+    mockAccessSync.mockImplementation((filePath) => {
+      if (filePath === '/mock/bin/forge-custom') {
+        return undefined;
+      }
+      throw new Error('not executable');
+    });
+
+    const { getCliDoctorStatus, findForgeCli } = await import('../cli-utils.js');
+    const status = getCliDoctorStatus();
+
+    expect(status.forge).toEqual({
+      configuredCommand: 'forge-custom',
+      resolvedPath: '/mock/bin/forge-custom',
+      available: true,
+      lookup: 'env',
+    });
+    expect(findForgeCli()).toBe('forge-custom');
   });
 });

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { cleanupSharedMock, getSharedMock } from './utils/persistent-mock.js';
@@ -17,6 +17,53 @@ function expectProcessSummaryShape(processInfo: any): void {
     agent: expect.any(String),
     status: expect.any(String),
   });
+}
+
+function createForgeMockScript(dir: string, argsLogPath: string): string {
+  const scriptPath = join(dir, 'mock-forge');
+  writeFileSync(
+    scriptPath,
+    `#!/bin/bash
+set -euo pipefail
+
+log_file="${argsLogPath}"
+prompt=""
+conversation_id=""
+
+printf '%s\\n' "$*" >> "$log_file"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C)
+      shift 2
+      ;;
+    -p)
+      prompt="$2"
+      shift 2
+      ;;
+    --conversation-id)
+      conversation_id="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$conversation_id" ]]; then
+  printf '● [21:09:33] Continue %s\\n' "$conversation_id"
+  printf 'Resumed: %s\\n' "$prompt"
+  printf '● [21:09:37] Finished %s\\n' "$conversation_id"
+else
+  printf '● [21:09:01] Initialize forge-session-1\\n'
+  printf 'Initial: %s\\n' "$prompt"
+  printf '● [21:09:08] Finished forge-session-1\\n'
+fi
+`
+  );
+  chmodSync(scriptPath, 0o755);
+  return scriptPath;
 }
 
 describe('MCP Contract Tests', () => {
@@ -152,6 +199,131 @@ describe('MCP Contract Tests', () => {
       agent: 'claude',
       message: expect.any(String),
     });
+  });
+
+  it('covers forge end-to-end through the MCP process path', async () => {
+    await client.disconnect();
+
+    const forgeArgsLogPath = join(testDir, 'forge-args.log');
+    const forgeMockPath = createForgeMockScript(testDir, forgeArgsLogPath);
+
+    client = createTestClient({
+      debug: false,
+      env: {
+        FORGE_CLI_NAME: forgeMockPath,
+      },
+    });
+    await client.connect();
+
+    const initialRunResponse = await client.callTool('run', {
+      prompt: 'forge-initial-prompt',
+      workFolder: testDir,
+      model: 'forge',
+    });
+    const initialRunData = parseToolJson(initialRunResponse);
+
+    expect(initialRunData).toEqual({
+      pid: expect.any(Number),
+      status: 'started',
+      agent: 'forge',
+      message: expect.any(String),
+    });
+
+    const initialWaitResponse = await client.callTool('wait', { pids: [initialRunData.pid], timeout: 5 });
+    const initialWaitData = parseToolJson(initialWaitResponse);
+
+    expect(initialWaitData).toHaveLength(1);
+    expect(initialWaitData[0]).toMatchObject({
+      pid: initialRunData.pid,
+      agent: 'forge',
+      status: 'completed',
+      session_id: 'forge-session-1',
+      agentOutput: {
+        message: 'Initial: forge-initial-prompt',
+        session_id: 'forge-session-1',
+      },
+    });
+
+    const initialResultResponse = await client.callTool('get_result', { pid: initialRunData.pid });
+    const initialResultData = parseToolJson(initialResultResponse);
+
+    expect(initialResultData).toMatchObject({
+      pid: initialRunData.pid,
+      agent: 'forge',
+      status: 'completed',
+      session_id: 'forge-session-1',
+      agentOutput: {
+        message: 'Initial: forge-initial-prompt',
+        session_id: 'forge-session-1',
+      },
+    });
+
+    const resumedRunResponse = await client.callTool('run', {
+      prompt: 'forge-resume-prompt',
+      workFolder: testDir,
+      model: 'forge',
+      session_id: 'forge-session-1',
+    });
+    const resumedRunData = parseToolJson(resumedRunResponse);
+
+    expect(resumedRunData).toEqual({
+      pid: expect.any(Number),
+      status: 'started',
+      agent: 'forge',
+      message: expect.any(String),
+    });
+
+    const resumedWaitResponse = await client.callTool('wait', { pids: [resumedRunData.pid], timeout: 5 });
+    const resumedWaitData = parseToolJson(resumedWaitResponse);
+
+    expect(resumedWaitData).toHaveLength(1);
+    expect(resumedWaitData[0]).toMatchObject({
+      pid: resumedRunData.pid,
+      agent: 'forge',
+      status: 'completed',
+      session_id: 'forge-session-1',
+      agentOutput: {
+        message: 'Resumed: forge-resume-prompt',
+        session_id: 'forge-session-1',
+      },
+    });
+
+    const resumedResultResponse = await client.callTool('get_result', { pid: resumedRunData.pid });
+    const resumedResultData = parseToolJson(resumedResultResponse);
+
+    expect(resumedResultData).toMatchObject({
+      pid: resumedRunData.pid,
+      agent: 'forge',
+      status: 'completed',
+      session_id: 'forge-session-1',
+      agentOutput: {
+        message: 'Resumed: forge-resume-prompt',
+        session_id: 'forge-session-1',
+      },
+    });
+
+    const forgeInvocations = readFileSync(forgeArgsLogPath, 'utf-8').trim().split('\n');
+    expect(forgeInvocations).toHaveLength(2);
+    expect(forgeInvocations[0]).toContain(`-C ${testDir}`);
+    expect(forgeInvocations[0]).toContain('-p forge-initial-prompt');
+    expect(forgeInvocations[0]).not.toContain('--model');
+    expect(forgeInvocations[0]).not.toContain('--agent');
+    expect(forgeInvocations[0]).not.toContain('--conversation-id');
+
+    expect(forgeInvocations[1]).toContain(`-C ${testDir}`);
+    expect(forgeInvocations[1]).toContain('--conversation-id forge-session-1');
+    expect(forgeInvocations[1]).toContain('-p forge-resume-prompt');
+    expect(forgeInvocations[1]).not.toContain('--model');
+    expect(forgeInvocations[1]).not.toContain('--agent');
+
+    await expect(
+      client.callTool('run', {
+        prompt: 'forge-invalid-reasoning',
+        workFolder: testDir,
+        model: 'forge',
+        reasoning_effort: 'high',
+      })
+    ).rejects.toThrow(/reasoning_effort is not supported for forge/i);
   });
 
   it('keeps key invalid-input errors stable', async () => {

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCodexOutput, parseClaudeOutput } from '../parsers.js';
+import { parseCodexOutput, parseClaudeOutput, parseForgeOutput } from '../parsers.js';
 
 describe('parseCodexOutput', () => {
   it('should parse basic Codex output with message and session_id', () => {
@@ -104,5 +104,48 @@ INVALID_LINE
 `;
     const result = parseClaudeOutput(output);
     expect(result.message).toBe("Success");
+  });
+});
+
+describe('parseForgeOutput', () => {
+  it('should parse initialized forge output with a conversation id', () => {
+    const output = `● [21:09:01] Initialize 123e4567-e89b-12d3-a456-426614174000
+Hello from Forge
+● [21:09:08] Finished 123e4567-e89b-12d3-a456-426614174000
+`;
+
+    expect(parseForgeOutput(output)).toEqual({
+      message: 'Hello from Forge',
+      session_id: '123e4567-e89b-12d3-a456-426614174000',
+    });
+  });
+
+  it('should parse resumed forge output with multiline assistant content', () => {
+    const output = `● [21:09:33] Continue conv-123
+Line one
+
+Line three
+● [21:09:37] Finished conv-123
+`;
+
+    expect(parseForgeOutput(output)).toEqual({
+      message: 'Line one\n\nLine three',
+      session_id: 'conv-123',
+    });
+  });
+
+  it('should return the current message while forge output is still in progress', () => {
+    const output = `● [21:09:33] Continue conv-456
+Partial answer
+still streaming`;
+
+    expect(parseForgeOutput(output)).toEqual({
+      message: 'Partial answer\nstill streaming',
+      session_id: 'conv-456',
+    });
+  });
+
+  it('should return null for unrelated forge output', () => {
+    expect(parseForgeOutput('plain text')).toBeNull();
   });
 });

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -26,9 +26,9 @@ Options:
   --cwd <path>                 Working directory
   --prompt <text>              Prompt text
   --prompt-file <path>         Path to a prompt file
-  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.2-codex, codex-ultra, gemini-2.5-pro, gemini-ultra)
+  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.2-codex, codex-ultra, gemini-2.5-pro, gemini-ultra, forge)
   --session-id <id>            Resume a previous session
-  --reasoning-effort <level>   Reasoning level for Claude/Codex
+  --reasoning-effort <level>   Reasoning level for Claude/Codex only
   --help, -h                   Show this help message
 
 Compatibility aliases:

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -8,7 +8,7 @@ import {
   type ServerResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { spawn } from 'node:child_process';
-import { debugLog, findClaudeCli, findCodexCli, findGeminiCli } from '../cli-utils.js';
+import { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from '../cli-utils.js';
 import { getModelParameterDescription, getSupportedModelsDescription } from '../model-catalog.js';
 import { ProcessService } from '../process-service.js';
 
@@ -72,6 +72,7 @@ export class ClaudeCodeServer {
   private claudeCliPath: string;
   private codexCliPath: string;
   private geminiCliPath: string;
+  private forgeCliPath: string;
   private processService: ProcessService;
   private sigintHandler?: () => Promise<void>;
   private packageVersion: string;
@@ -80,15 +81,18 @@ export class ClaudeCodeServer {
     this.claudeCliPath = findClaudeCli();
     this.codexCliPath = findCodexCli();
     this.geminiCliPath = findGeminiCli();
+    this.forgeCliPath = findForgeCli();
     console.error(`[Setup] Using Claude CLI command/path: ${this.claudeCliPath}`);
     console.error(`[Setup] Using Codex CLI command/path: ${this.codexCliPath}`);
     console.error(`[Setup] Using Gemini CLI command/path: ${this.geminiCliPath}`);
+    console.error(`[Setup] Using Forge CLI command/path: ${this.forgeCliPath}`);
     this.packageVersion = SERVER_VERSION;
     this.processService = new ProcessService({
       cliPaths: {
         claude: this.claudeCliPath,
         codex: this.codexCliPath,
         gemini: this.geminiCliPath,
+        forge: this.forgeCliPath,
       },
     });
 
@@ -119,7 +123,7 @@ export class ClaudeCodeServer {
       tools: [
         {
           name: 'run',
-          description: `AI Agent Runner: Starts a Claude, Codex, or Gemini CLI process in the background and returns a PID immediately. Use list_processes and get_result to monitor progress.
+          description: `AI Agent Runner: Starts a Claude, Codex, Gemini, or Forge CLI process in the background and returns a PID immediately. Use list_processes and get_result to monitor progress.
 
 • File ops: Create, read, (fuzzy) edit, move, copy, delete, list files, analyze/ocr images, file content analysis
 • Code: Generate / analyse / refactor / fix
@@ -163,11 +167,11 @@ ${getSupportedModelsDescription()}
               },
               reasoning_effort: {
                 type: 'string',
-                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh".',
+                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh". Forge does not support reasoning_effort in this integration.',
               },
               session_id: {
                 type: 'string',
-                description: 'Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview.',
+                description: 'Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview, forge.',
               },
             },
             required: ['workFolder'],

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -5,7 +5,10 @@ import { MODEL_ALIASES } from './model-catalog.js';
 export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
 const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high']);
 
-function getAgentForModel(model: string): 'codex' | 'claude' | 'gemini' {
+function getAgentForModel(model: string): 'codex' | 'claude' | 'gemini' | 'forge' {
+  if (model === 'forge') {
+    return 'forge';
+  }
   if (model.startsWith('gpt-')) {
     return 'codex';
   }
@@ -44,6 +47,9 @@ export function getReasoningEffort(model: string, rawValue: unknown): string {
     );
   }
   const agent = getAgentForModel(model);
+  if (agent === 'forge') {
+    throw new Error('reasoning_effort is not supported for forge.');
+  }
   if (agent === 'gemini') {
     throw new Error(
       'reasoning_effort is only supported for Claude and Codex models.'
@@ -61,7 +67,7 @@ export interface CliCommand {
   cliPath: string;
   args: string[];
   cwd: string;
-  agent: 'claude' | 'codex' | 'gemini';
+  agent: 'claude' | 'codex' | 'gemini' | 'forge';
   prompt: string;
   resolvedModel: string;
 }
@@ -73,7 +79,7 @@ export interface BuildCliCommandOptions {
   model?: string;
   session_id?: string;
   reasoning_effort?: string;
-  cliPaths: { claude: string; codex: string; gemini: string };
+  cliPaths: { claude: string; codex: string; gemini: string; forge: string };
 }
 
 /**
@@ -178,6 +184,15 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
 
     args.push(prompt);
 
+  } else if (agent === 'forge') {
+    cliPath = options.cliPaths.forge;
+    args = ['-C', cwd];
+
+    if (options.session_id && typeof options.session_id === 'string') {
+      args.push('--conversation-id', options.session_id);
+    }
+
+    args.push('-p', prompt);
   } else {
     cliPath = options.cliPaths.claude;
     args = ['--dangerously-skip-permissions', '--output-format', 'stream-json', '--verbose'];

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
-import { parseClaudeOutput, parseCodexOutput, parseGeminiOutput } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
 
-const AGENTS = ['claude', 'codex', 'gemini'] as const;
+const AGENTS = ['claude', 'codex', 'gemini', 'forge'] as const;
 type Agent = typeof AGENTS[number];
 
-const USAGE = `Usage: npm run -s cli.run.parse -- --agent <claude|codex|gemini>
+const USAGE = `Usage: npm run -s cli.run.parse -- --agent <claude|codex|gemini|forge>
 
 Reads raw CLI output from stdin and outputs parsed JSON to stdout.
 
 Options:
-  --agent   Agent type: claude, codex, or gemini (required)
+  --agent   Agent type: claude, codex, gemini, or forge (required)
   --help    Show this help message
 
 Examples:
@@ -62,7 +62,7 @@ async function main(): Promise<void> {
 
   const agent = args.agent as Agent;
   if (!agent || !AGENTS.includes(agent)) {
-    process.stderr.write(`Error: --agent is required (claude, codex, or gemini)\n\n`);
+    process.stderr.write(`Error: --agent is required (claude, codex, gemini, or forge)\n\n`);
     process.stderr.write(USAGE);
     process.exit(1);
   }
@@ -84,6 +84,9 @@ async function main(): Promise<void> {
       break;
     case 'gemini':
       parsed = parseGeminiOutput(input);
+      break;
+    case 'forge':
+      parsed = parseForgeOutput(input);
       break;
   }
 

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -15,8 +15,8 @@ import {
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { findClaudeCli, findCodexCli, findGeminiCli } from './cli-utils.js';
-import { parseClaudeOutput, parseCodexOutput, parseGeminiOutput } from './parsers.js';
+import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
 import type { AgentType, ProcessListItem } from './process-service.js';
 
 interface StoredProcess {
@@ -78,6 +78,7 @@ export class CliProcessService {
       claude: findClaudeCli(),
       codex: findCodexCli(),
       gemini: findGeminiCli(),
+      forge: findForgeCli(),
     };
     mkdirSync(this.stateDir, { recursive: true });
   }
@@ -177,6 +178,8 @@ export class CliProcessService {
         agentOutput = parseClaudeOutput(stdout);
       } else if (refreshed.toolType === 'gemini') {
         agentOutput = parseGeminiOutput(stdout);
+      } else if (refreshed.toolType === 'forge') {
+        agentOutput = parseForgeOutput(stdout);
       }
     }
 

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -148,7 +148,7 @@ function isExecutableFile(filePath: string): boolean {
   }
 }
 
-type CliBinaryName = 'claude' | 'codex' | 'gemini';
+type CliBinaryName = 'claude' | 'codex' | 'gemini' | 'forge';
 
 function getCliBinaryConfig(name: CliBinaryName): {
   envVarName: string;
@@ -174,6 +174,15 @@ function getCliBinaryConfig(name: CliBinaryName): {
     };
   }
 
+  if (name === 'forge') {
+    return {
+      envVarName: 'FORGE_CLI_NAME',
+      customCliName: process.env.FORGE_CLI_NAME,
+      defaultCliName: 'forge',
+      localInstallPath: join(homedir(), '.forge', 'local', 'forge'),
+    };
+  }
+
   return {
     envVarName: 'GEMINI_CLI_NAME',
     customCliName: process.env.GEMINI_CLI_NAME,
@@ -190,11 +199,13 @@ export function getCliDoctorStatus(): {
   claude: CliBinaryStatus;
   codex: CliBinaryStatus;
   gemini: CliBinaryStatus;
+  forge: CliBinaryStatus;
 } {
   return {
     claude: getCliBinaryStatus('claude'),
     codex: getCliBinaryStatus('codex'),
     gemini: getCliBinaryStatus('gemini'),
+    forge: getCliBinaryStatus('forge'),
   };
 }
 
@@ -215,6 +226,15 @@ export function findGeminiCli(): string {
 export function findCodexCli(): string {
   debugLog('[Debug] Attempting to find Codex CLI...');
   const status = getCliBinaryStatus('codex');
+  return getCliCommandOrThrow(status);
+}
+
+/**
+ * Determine the Forge CLI command/path.
+ */
+export function findForgeCli(): string {
+  debugLog('[Debug] Attempting to find Forge CLI...');
+  const status = getCliBinaryStatus('forge');
   return getCliCommandOrThrow(status);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { buildCliCommand } from './cli-builder.js';
-import { findClaudeCli, findCodexCli, findGeminiCli } from './cli-utils.js';
+import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
 
 /**
  * Minimal argv parser. No external dependencies.
@@ -35,12 +35,12 @@ function parseArgs(argv: string[]): Record<string, string> {
 const USAGE = `Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]
 
 Options:
-  --model              Model name or alias (e.g. sonnet, opus, gpt-5.2-codex, gemini-2.5-pro)
+  --model              Model name or alias (e.g. sonnet, opus, gpt-5.2-codex, gemini-2.5-pro, forge)
   --workFolder         Working directory (absolute path)
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt
   --session_id         Session ID to resume
-  --reasoning_effort   Claude/Codex: Claude=low|medium|high, Codex=low|medium|high|xhigh
+  --reasoning_effort   Claude/Codex only: Claude=low|medium|high, Codex=low|medium|high|xhigh
   --help               Show this help message
 
 Raw CLI output goes to stdout. Use cli.run.parse to parse the output:
@@ -73,6 +73,7 @@ async function main(): Promise<void> {
     claude: findClaudeCli(),
     codex: findCodexCli(),
     gemini: findGeminiCli(),
+    forge: findForgeCli(),
   };
 
   // Build command

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -19,6 +19,7 @@ export const GEMINI_MODELS = [
   'gemini-3-pro-preview',
   'gemini-3-flash-preview',
 ] as const;
+export const FORGE_MODELS = ['forge'] as const;
 
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
@@ -38,11 +39,12 @@ export function getSupportedModelsDescription(): string {
     ...CLAUDE_MODELS.map((model) => `"${model}"`),
     ...CODEX_MODELS.map((model) => `"${model}"`),
     ...GEMINI_MODELS.map((model) => `"${model}"`),
+    ...FORGE_MODELS.map((model) => `"${model}"`),
   ].join(', ');
 }
 
 export function getModelParameterDescription(): string {
-  return `The model to use. Aliases: "claude-ultra" (auto high effort), "codex-ultra" (auto xhigh reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS].map((model) => `"${model}"`).join(', ')}.`;
+  return `The model to use. Aliases: "claude-ultra" (auto high effort), "codex-ultra" (auto xhigh reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS, ...FORGE_MODELS].map((model) => `"${model}"`).join(', ')}. "forge" is a provider key, not a Forge model family selector.`;
 }
 
 export function getModelsPayload(): {
@@ -50,11 +52,13 @@ export function getModelsPayload(): {
   claude: ReadonlyArray<string>;
   codex: ReadonlyArray<string>;
   gemini: ReadonlyArray<string>;
+  forge: ReadonlyArray<string>;
 } {
   return {
     aliases: MODEL_ALIAS_DETAILS,
     claude: CLAUDE_MODELS,
     codex: CODEX_MODELS,
     gemini: GEMINI_MODELS,
+    forge: FORGE_MODELS,
   };
 }

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -167,3 +167,64 @@ export function parseGeminiOutput(stdout: string): any {
     return null;
   }
 }
+
+/**
+ * Parse Forge output framed by Initialize/Continue/Finished markers.
+ */
+export function parseForgeOutput(stdout: string): any {
+  if (!stdout) return null;
+
+  const lines = stdout.split('\n');
+  const markerPattern = /^● \[[^\]]+\] (Initialize|Continue|Finished) (\S+)\s*$/;
+  let collecting = false;
+  let currentConversationId: string | null = null;
+  let currentBody: string[] = [];
+  let lastConversationId: string | null = null;
+  let lastMessage: string | null = null;
+
+  for (const line of lines) {
+    const match = line.match(markerPattern);
+    if (match) {
+      const [, action, conversationId] = match;
+      lastConversationId = conversationId;
+
+      if (action === 'Initialize' || action === 'Continue') {
+        collecting = true;
+        currentConversationId = conversationId;
+        currentBody = [];
+      } else if (collecting && currentConversationId === conversationId) {
+        const message = currentBody.join('\n').trim();
+        if (message) {
+          lastMessage = message;
+        }
+        collecting = false;
+        currentConversationId = null;
+        currentBody = [];
+      }
+      continue;
+    }
+
+    if (collecting) {
+      currentBody.push(line);
+    }
+  }
+
+  if (collecting) {
+    const message = currentBody.join('\n').trim();
+    if (message) {
+      lastMessage = message;
+    }
+    if (currentConversationId) {
+      lastConversationId = currentConversationId;
+    }
+  }
+
+  if (!lastMessage && !lastConversationId) {
+    return null;
+  }
+
+  return {
+    message: lastMessage,
+    session_id: lastConversationId,
+  };
+}

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { parseClaudeOutput, parseCodexOutput, parseGeminiOutput } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
 
-export type AgentType = 'claude' | 'codex' | 'gemini';
+export type AgentType = 'claude' | 'codex' | 'gemini' | 'forge';
 export type ProcessStatus = 'running' | 'completed' | 'failed';
 
 interface TrackedProcess {
@@ -144,6 +144,8 @@ export class ProcessService {
         agentOutput = parseClaudeOutput(process.stdout);
       } else if (process.toolType === 'gemini') {
         agentOutput = parseGeminiOutput(process.stdout);
+      } else if (process.toolType === 'forge') {
+        agentOutput = parseForgeOutput(process.stdout);
       }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-export { debugLog, findClaudeCli, findCodexCli, findGeminiCli } from './cli-utils.js';
+export { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
 export { resolveModelAlias } from './cli-builder.js';
 export { ClaudeCodeServer, runMcpServer, spawnAsync } from './app/mcp.js';
 


### PR DESCRIPTION
## Summary

Forge CLI を新しい AI バックエンドとして追加する。`model: 'forge'` を指定することで、`forge -C <workFolder> -p <prompt>` 形式で Forge を非対話モードで実行でき、`--conversation-id` によるセッション再開もサポートする。

## Type of Change

- [x] feat: New feature

## Changes

- `src/parsers.ts`: `parseForgeOutput` を追加。Forge の `● [時刻] Initialize/Continue/Finished <id>` マーカー形式を解析し `message` と `session_id` を返す
- `src/cli-builder.ts`: `getAgentForModel` に `'forge'` エージェント判定を追加。`buildCliCommand` で Forge コマンド（`-C`, `-p`, `--conversation-id`）を組み立て。`reasoning_effort` 指定時はエラーを throw
- `src/cli-utils.ts`: `findForgeCli` / `getCliBinaryConfig('forge')` を追加。`FORGE_CLI_NAME` 環境変数または PATH 上の `forge` を使用
- `src/model-catalog.ts`: `FORGE_MODELS = ['forge']` を追加し、モデル一覧・説明に含める
- `src/process-service.ts` / `src/cli-process-service.ts`: `AgentType` に `'forge'` を追加し、`parseForgeOutput` でアウトプットを解析
- `src/app/mcp.ts`: `forgeCliPath` フィールドを追加し、`ProcessService` の `cliPaths` に渡す。MCP ツール説明文を更新
- `src/server.ts`: `findForgeCli` を public export に追加
- `src/cli.ts` / `src/cli-parse.ts` / `src/app/cli.ts`: Forge 対応のコマンド引数・ヘルプ文言を更新
- テスト: `parsers`, `cli-builder`, `cli-utils`, `cli-process-service`, `mcp-contract`, `app-cli`, `cli-bin-smoke` の各テストファイルに Forge 向けケースを追加
- ドキュメント: `README.md` / `README.ja.md` / `server.json` に Forge サポートを記載

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

- `reasoning_effort` は Forge では非サポート（指定時はエラー）
- `session_id` は Forge の `--conversation-id` にマッピングされる
- `FORGE_CLI_NAME` 環境変数でバイナリパスを上書き可能（デフォルト: `forge`）
- Forge の出力パース対象マーカー: `● [HH:MM:SS] Initialize|Continue|Finished <conversation_id>`
