### PR TITLE
feat: add compact/verbose output shape to get_result and wait

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -118,7 +118,9 @@ ai-cli models
 ai-cli run --cwd "$PWD" --model sonnet --prompt "summarize this repository"
 ai-cli ps
 ai-cli result 12345
+ai-cli result 12345 --verbose
 ai-cli wait 12345 --timeout 300
+ai-cli wait 12345 --verbose
 ai-cli kill 12345
 ai-cli cleanup
 ai-cli-mcp
@@ -185,7 +187,9 @@ ai-cli models
 ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
 ai-cli ps
 ai-cli wait 12345
+ai-cli wait 12345 --verbose
 ai-cli result 12345
+ai-cli result 12345 --verbose
 ai-cli cleanup
 ```
 
@@ -244,9 +248,12 @@ Claude CLI、Codex CLI、Gemini CLI、または Forge CLI を使用してプロ�
 
 複数のAIエージェントプロセスの完了を待機し、結果をまとめて返します。指定されたすべてのPIDが終了するか、タイムアウトになるまでブロックします。
 
+デフォルトでは、返される各結果項目は `get_result(verbose: false)` と同じ compact 形を使います。`pid`、`agent`、`status`、`exitCode`、`model` などの運用上必要な項目に加え、利用可能であれば `agentOutput` やトップレベルの `session_id` を含みます。`verbose: true` を指定すると、`startTime`、`workFolder`、`prompt` などの完全なメタデータや、`agentOutput.tools` のような詳細な解析結果を含む full 形を返します。
+
 **引数:**
 - `pids` (array of numbers, 必須): 待機するプロセスIDのリスト（`run` ツールから返されたもの）。
 - `timeout` (number, 任意): 最大待機時間（秒）。デフォルトは180秒（3分）です。
+- `verbose` (boolean, 任意): `true` の場合、各結果項目を full 形で返します。デフォルトは `false` です。
 
 ### `list_processes`
 
@@ -256,8 +263,11 @@ Claude CLI、Codex CLI、Gemini CLI、または Forge CLI を使用してプロ�
 
 PIDを指定して、AIエージェントプロセスの現在の出力とステータスを取得します。
 
+デフォルトでは compact 形を返します。これには `pid`、`agent`、`status`、`exitCode`、`model` などの運用上必要な項目に加え、利用可能であれば `agentOutput` やトップレベルの `session_id` を含みます。`startTime`、`workFolder`、`prompt` は含みません。`verbose: true` を指定すると、これらのメタデータや `agentOutput.tools` のような詳細な解析結果を含む full 形を返します。解析結果が得られない場合や不完全な場合は、従来どおり `stdout` / `stderr` のフォールバックを維持します。
+
 **引数:**
 - `pid` (number, 必須): `run` ツールによって返されたプロセスID。
+- `verbose` (boolean, 任意): `true` の場合、full 形で返します。デフォルトは `false` です。
 
 ### `kill_process`
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ ai-cli models
 ai-cli run --cwd "$PWD" --model sonnet --prompt "summarize this repository"
 ai-cli ps
 ai-cli result 12345
+ai-cli result 12345 --verbose
 ai-cli wait 12345 --timeout 300
+ai-cli wait 12345 --verbose
 ai-cli kill 12345
 ai-cli cleanup
 ai-cli-mcp
@@ -183,7 +185,9 @@ ai-cli models
 ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
 ai-cli ps
 ai-cli wait 12345
+ai-cli wait 12345 --verbose
 ai-cli result 12345
+ai-cli result 12345 --verbose
 ai-cli cleanup
 ```
 
@@ -242,9 +246,12 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, or Forge CLI. The app
 
 Waits for multiple AI agent processes to complete and returns their combined results. Blocks until all specified PIDs finish or a timeout occurs.
 
+By default, each returned result item uses the compact shape shared with `get_result(verbose: false)`: operational fields such as `pid`, `agent`, `status`, `exitCode`, `model`, parsed output such as `agentOutput`, and top-level `session_id` when available. Set `verbose: true` to include full metadata like `startTime`, `workFolder`, `prompt`, and detailed parsed output such as `agentOutput.tools`.
+
 **Arguments:**
 - `pids` (array of numbers, required): List of process IDs to wait for (returned by the `run` tool).
 - `timeout` (number, optional): Maximum wait time in seconds. Defaults to 180 (3 minutes).
+- `verbose` (boolean, optional): If `true`, each result item uses the full result shape. Defaults to `false`.
 
 ### `list_processes`
 
@@ -254,8 +261,11 @@ Lists all running and completed AI agent processes with their status, PID, and b
 
 Gets the current output and status of an AI agent process by PID.
 
+By default, this returns the compact result shape: operational fields such as `pid`, `agent`, `status`, `exitCode`, `model`, parsed output such as `agentOutput`, and top-level `session_id` when available. It omits metadata fields like `startTime`, `workFolder`, and `prompt`. Set `verbose: true` to return the full result shape including those metadata fields and detailed parsed output such as `agentOutput.tools`. If parsed output is unavailable or incomplete, the raw `stdout`/`stderr` fallback is preserved.
+
 **Arguments:**
 - `pid` (number, required): The process ID returned by the `run` tool.
+- `verbose` (boolean, optional): If `true`, returns the full result shape. Defaults to `false`.
 
 ### `kill_process`
 

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -3,6 +3,7 @@ import {
   CLI_HELP_TEXT,
   DOCTOR_HELP_TEXT,
   MODELS_HELP_TEXT,
+  RESULT_HELP_TEXT,
   RUN_HELP_TEXT,
   WAIT_HELP_TEXT,
   runCli,
@@ -142,8 +143,26 @@ describe('ai-cli app', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(waitForProcesses).toHaveBeenCalledWith([123, 456], 5);
+    expect(waitForProcesses).toHaveBeenCalledWith([123, 456], 5, false);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"status": "completed"'));
+  });
+
+  it('passes verbose through to wait', async () => {
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+    const waitForProcesses = vi.fn().mockResolvedValue([{ pid: 123, status: 'completed' }]);
+
+    const exitCode = await runCli(
+      ['wait', '123', '--verbose'],
+      {
+        stdout,
+        stderr,
+        waitForProcesses,
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(waitForProcesses).toHaveBeenCalledWith([123], undefined, true);
   });
 
   it('rejects invalid wait timeout values', async () => {
@@ -291,6 +310,19 @@ describe('ai-cli app', () => {
     expect(stderr).not.toHaveBeenCalled();
   });
 
+  it('prints detailed help for result --help', async () => {
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+
+    const exitCode = await runCli(['result', '--help'], { stdout, stderr });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(RESULT_HELP_TEXT);
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('compact result shape'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('--verbose'));
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
   it('prints detailed help for wait --help', async () => {
     const stdout = vi.fn();
     const stderr = vi.fn();
@@ -299,6 +331,8 @@ describe('ai-cli app', () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toHaveBeenCalledWith(WAIT_HELP_TEXT);
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('compact shape'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('--verbose'));
     expect(stderr).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -84,8 +84,18 @@ describe('CliProcessService', () => {
 
     const waitResult = await service.waitForProcesses([runResult.pid], 5);
     expect(waitResult).toHaveLength(1);
-    expect(waitResult[0].pid).toBe(runResult.pid);
-    expect(waitResult[0].status).toBe('completed');
+    expect(waitResult[0]).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: null,
+      model: 'sonnet',
+      stdout: expect.any(String),
+      stderr: expect.any(String),
+    });
+    expect(waitResult[0]).not.toHaveProperty('startTime');
+    expect(waitResult[0]).not.toHaveProperty('workFolder');
+    expect(waitResult[0]).not.toHaveProperty('prompt');
 
     const listed = await service.listProcesses();
     expect(listed).toContainEqual({
@@ -95,10 +105,139 @@ describe('CliProcessService', () => {
     });
 
     const result = await service.getProcessResult(runResult.pid, false);
-    expect(result.pid).toBe(runResult.pid);
-    expect(result.status).toBe('completed');
-    expect(result.stdout).toContain('Command executed successfully');
+    expect(result).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: null,
+      model: 'sonnet',
+      stdout: expect.stringContaining('Command executed successfully'),
+      stderr: expect.any(String),
+    });
+    expect(result).not.toHaveProperty('startTime');
+    expect(result).not.toHaveProperty('workFolder');
+    expect(result).not.toHaveProperty('prompt');
     expect(readFileSync(join(processDir, 'meta.json'), 'utf-8')).toContain('"status": "completed"');
+  });
+
+  it('returns compact results by default and full results when verbose is true', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const scriptPath = join(root, 'mock-claude-json');
+    writeFileSync(
+      scriptPath,
+      `#!/bin/bash
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/demo.txt"}}]}}'
+printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":[{"type":"text","text":"demo output"}]}]}}'
+printf '%s\n' '{"type":"result","result":"Completed cli-process-service test"}'
+printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
+`
+    );
+    chmodSync(scriptPath, 0o755);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'work');
+    mkdirSync(workFolder, { recursive: true });
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: scriptPath,
+        codex: scriptPath,
+        gemini: scriptPath,
+        forge: scriptPath,
+      },
+    });
+
+    const runResult = await service.startProcess({
+      prompt: 'hello structured output',
+      cwd: workFolder,
+    });
+
+    const compactWait = await service.waitForProcesses([runResult.pid], 5);
+    expect(compactWait).toHaveLength(1);
+    expect(compactWait[0]).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: null,
+      model: null,
+      session_id: 'session-cli-1',
+      agentOutput: {
+        message: 'Completed cli-process-service test',
+        session_id: 'session-cli-1',
+      },
+    });
+    expect(compactWait[0]).not.toHaveProperty('startTime');
+    expect(compactWait[0]).not.toHaveProperty('workFolder');
+    expect(compactWait[0]).not.toHaveProperty('prompt');
+    expect(compactWait[0].agentOutput).not.toHaveProperty('tools');
+
+    const compactResult = await service.getProcessResult(runResult.pid, false);
+    expect(compactResult).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: null,
+      model: null,
+      session_id: 'session-cli-1',
+      agentOutput: {
+        message: 'Completed cli-process-service test',
+        session_id: 'session-cli-1',
+      },
+    });
+    expect(compactResult).not.toHaveProperty('startTime');
+    expect(compactResult).not.toHaveProperty('workFolder');
+    expect(compactResult).not.toHaveProperty('prompt');
+    expect(compactResult.agentOutput).not.toHaveProperty('tools');
+
+    const verboseWait = await service.waitForProcesses([runResult.pid], 5, true);
+    expect(verboseWait).toHaveLength(1);
+    expect(verboseWait[0]).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: null,
+      model: null,
+      startTime: expect.any(String),
+      workFolder,
+      prompt: 'hello structured output',
+      session_id: 'session-cli-1',
+      agentOutput: {
+        message: 'Completed cli-process-service test',
+        session_id: 'session-cli-1',
+        tools: [
+          {
+            tool: 'Read',
+            input: { file_path: '/tmp/demo.txt' },
+            output: 'demo output',
+          },
+        ],
+      },
+    });
+
+    const verboseResult = await service.getProcessResult(runResult.pid, true);
+    expect(verboseResult).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: null,
+      model: null,
+      startTime: expect.any(String),
+      workFolder,
+      prompt: 'hello structured output',
+      session_id: 'session-cli-1',
+      agentOutput: {
+        message: 'Completed cli-process-service test',
+        session_id: 'session-cli-1',
+        tools: [
+          {
+            tool: 'Read',
+            input: { file_path: '/tmp/demo.txt' },
+            output: 'demo output',
+          },
+        ],
+      },
+    });
   });
 
   it('can terminate a tracked process', async () => {

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -122,6 +122,7 @@ describe('MCP Contract Tests', () => {
     expect(Object.keys(waitTool.inputSchema.properties).sort()).toEqual([
       'pids',
       'timeout',
+      'verbose',
     ]);
   });
 
@@ -155,22 +156,32 @@ describe('MCP Contract Tests', () => {
       pid: runData.pid,
       agent: 'claude',
       status: expect.any(String),
-      startTime: expect.any(String),
-      workFolder: testDir,
-      prompt: 'create a file called contract.txt with content "hello"',
       model: 'haiku',
       stdout: expect.any(String),
       stderr: expect.any(String),
     });
+    expect(getResultData).toHaveProperty('exitCode');
+    expect(getResultData).not.toHaveProperty('startTime');
+    expect(getResultData).not.toHaveProperty('workFolder');
+    expect(getResultData).not.toHaveProperty('prompt');
 
     const waitResponse = await client.callTool('wait', { pids: [runData.pid], timeout: 5 });
     const waitData = parseToolJson(waitResponse);
 
     expect(Array.isArray(waitData)).toBe(true);
     expect(waitData).toHaveLength(1);
-    expect(waitData[0].pid).toBe(runData.pid);
-    expect(waitData[0].agent).toBe('claude');
-    expect(waitData[0].status).toBe('completed');
+    expect(waitData[0]).toMatchObject({
+      pid: runData.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: 0,
+      model: 'haiku',
+      stdout: expect.any(String),
+      stderr: expect.any(String),
+    });
+    expect(waitData[0]).not.toHaveProperty('startTime');
+    expect(waitData[0]).not.toHaveProperty('workFolder');
+    expect(waitData[0]).not.toHaveProperty('prompt');
 
     const cleanupResponse = await client.callTool('cleanup_processes', {});
     const cleanupData = parseToolJson(cleanupResponse);
@@ -183,13 +194,14 @@ describe('MCP Contract Tests', () => {
     expect(cleanupData.removedPids).toContain(runData.pid);
   });
 
-  it('accepts prompt_file and keeps the run response shape stable', async () => {
+  it('preserves successful prompt_file execution through the MCP process path', async () => {
     const promptFile = join(testDir, 'prompt.txt');
-    writeFileSync(promptFile, 'create a file called from-file.txt');
+    writeFileSync(promptFile, 'Create a file from prompt_file');
 
     const runResponse = await client.callTool('run', {
       prompt_file: promptFile,
       workFolder: testDir,
+      model: 'haiku',
     });
     const runData = parseToolJson(runResponse);
 
@@ -198,6 +210,138 @@ describe('MCP Contract Tests', () => {
       status: 'started',
       agent: 'claude',
       message: expect.any(String),
+    });
+
+    const waitResponse = await client.callTool('wait', { pids: [runData.pid], timeout: 5 });
+    const waitData = parseToolJson(waitResponse);
+
+    expect(waitData).toHaveLength(1);
+    expect(waitData[0]).toMatchObject({
+      pid: runData.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: 0,
+      model: 'haiku',
+      stdout: expect.stringContaining('Created file successfully'),
+      stderr: '',
+    });
+    expect(waitData[0]).not.toHaveProperty('prompt');
+    expect(waitData[0]).not.toHaveProperty('workFolder');
+    expect(waitData[0]).not.toHaveProperty('startTime');
+  });
+
+  it('returns compact results by default and full results when verbose is true for parsed output', async () => {
+    await client.disconnect();
+
+    const verboseMockPath = join(testDir, 'verbose-claude');
+    writeFileSync(
+      verboseMockPath,
+      `#!/bin/bash
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/demo.txt"}}]}}'
+printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":[{"type":"text","text":"demo output"}]}]}}'
+printf '%s\n' '{"type":"result","result":"Completed contract verbose test"}'
+printf '%s\n' '{"type":"system","session_id":"session-verbose-1"}'
+`
+    );
+    chmodSync(verboseMockPath, 0o755);
+
+    client = createTestClient({ claudeCliName: verboseMockPath, debug: false });
+    await client.connect();
+
+    const runResponse = await client.callTool('run', {
+      prompt: 'verbose-shape-test',
+      workFolder: testDir,
+    });
+    const runData = parseToolJson(runResponse);
+
+    const completedWait = parseToolJson(await client.callTool('wait', { pids: [runData.pid], timeout: 5 }));
+    expect(completedWait).toHaveLength(1);
+    expect(completedWait[0].status).toBe('completed');
+
+    const compactResult = parseToolJson(await client.callTool('get_result', { pid: runData.pid }));
+    expect(compactResult).toMatchObject({
+      pid: runData.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: 0,
+      model: null,
+      session_id: 'session-verbose-1',
+      agentOutput: {
+        message: 'Completed contract verbose test',
+        session_id: 'session-verbose-1',
+      },
+    });
+    expect(compactResult).not.toHaveProperty('startTime');
+    expect(compactResult).not.toHaveProperty('workFolder');
+    expect(compactResult).not.toHaveProperty('prompt');
+    expect(compactResult.agentOutput).not.toHaveProperty('tools');
+
+    const verboseResult = parseToolJson(await client.callTool('get_result', { pid: runData.pid, verbose: true }));
+    expect(verboseResult).toMatchObject({
+      pid: runData.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: 0,
+      model: null,
+      startTime: expect.any(String),
+      workFolder: testDir,
+      prompt: 'verbose-shape-test',
+      session_id: 'session-verbose-1',
+      agentOutput: {
+        message: 'Completed contract verbose test',
+        session_id: 'session-verbose-1',
+        tools: [
+          {
+            tool: 'Read',
+            input: { file_path: '/tmp/demo.txt' },
+            output: 'demo output',
+          },
+        ],
+      },
+    });
+
+    const compactWait = parseToolJson(await client.callTool('wait', { pids: [runData.pid], timeout: 5 }));
+    expect(compactWait).toHaveLength(1);
+    expect(compactWait[0]).toMatchObject({
+      pid: runData.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: 0,
+      model: null,
+      session_id: 'session-verbose-1',
+      agentOutput: {
+        message: 'Completed contract verbose test',
+        session_id: 'session-verbose-1',
+      },
+    });
+    expect(compactWait[0]).not.toHaveProperty('startTime');
+    expect(compactWait[0]).not.toHaveProperty('workFolder');
+    expect(compactWait[0]).not.toHaveProperty('prompt');
+    expect(compactWait[0].agentOutput).not.toHaveProperty('tools');
+
+    const verboseWait = parseToolJson(await client.callTool('wait', { pids: [runData.pid], timeout: 5, verbose: true }));
+    expect(verboseWait).toHaveLength(1);
+    expect(verboseWait[0]).toMatchObject({
+      pid: runData.pid,
+      agent: 'claude',
+      status: 'completed',
+      exitCode: 0,
+      model: null,
+      startTime: expect.any(String),
+      workFolder: testDir,
+      prompt: 'verbose-shape-test',
+      session_id: 'session-verbose-1',
+      agentOutput: {
+        message: 'Completed contract verbose test',
+        session_id: 'session-verbose-1',
+        tools: [
+          {
+            tool: 'Read',
+            input: { file_path: '/tmp/demo.txt' },
+            output: 'demo output',
+          },
+        ],
+      },
     });
   });
 

--- a/src/__tests__/process-management.test.ts
+++ b/src/__tests__/process-management.test.ts
@@ -191,7 +191,8 @@ describe('Process Management Tests', () => {
         params: {
           name: 'get_result',
           arguments: {
-            pid: 12360
+            pid: 12360,
+            verbose: true
           }
         }
       });

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -41,18 +41,20 @@ Compatibility aliases:
 export const WAIT_HELP_TEXT = `Usage: ai-cli wait <pid...> [options]
 
 Wait for one or more tracked processes to finish.
+By default each result uses the compact shape; set --verbose to include full metadata and detailed parsed output.
 
 Options:
   --timeout <seconds>          Maximum wait time in seconds
+  --verbose                    Return full metadata and detailed parsed output
   --help, -h                   Show this help message
 `;
 
 export const RESULT_HELP_TEXT = `Usage: ai-cli result <pid> [options]
 
-Get the current result for a tracked process.
+Get the current output and status of a tracked process. By default this returns a compact result shape; set --verbose to include full metadata and detailed parsed output.
 
 Options:
-  --verbose                    Include verbose parsed output
+  --verbose                    Return full metadata and detailed parsed output
   --help, -h                   Show this help message
 `;
 
@@ -115,7 +117,7 @@ interface CliDeps {
   }) => Promise<any>;
   listProcesses: () => Promise<any>;
   getProcessResult: (pid: number, verbose: boolean) => Promise<any>;
-  waitForProcesses: (pids: number[], timeoutSeconds?: number) => Promise<any>;
+  waitForProcesses: (pids: number[], timeoutSeconds?: number, verbose?: boolean) => Promise<any>;
   killProcess: (pid: number) => Promise<any>;
   cleanupProcesses: () => Promise<any>;
   getDoctorStatus: () => any;
@@ -137,7 +139,7 @@ const defaultDeps: CliDeps = {
   runProcess: (options) => getCliProcessService().startProcess(options),
   listProcesses: () => getCliProcessService().listProcesses(),
   getProcessResult: (pid, verbose) => getCliProcessService().getProcessResult(pid, verbose),
-  waitForProcesses: (pids, timeoutSeconds) => getCliProcessService().waitForProcesses(pids, timeoutSeconds),
+  waitForProcesses: (pids, timeoutSeconds, verbose) => getCliProcessService().waitForProcesses(pids, timeoutSeconds, verbose),
   killProcess: (pid) => getCliProcessService().killProcess(pid),
   cleanupProcesses: () => getCliProcessService().cleanupProcesses(),
   getDoctorStatus: () => getCliDoctorStatus(),
@@ -317,7 +319,7 @@ export async function runCli(argv: string[], deps: Partial<CliDeps> = {}): Promi
       return 1;
     }
 
-    writeJson(stdout, await waitForProcesses(pids as number[], timeout));
+    writeJson(stdout, await waitForProcesses(pids as number[], timeout, 'verbose' in flags));
     return 0;
   }
 

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -187,7 +187,7 @@ ${getSupportedModelsDescription()}
         },
         {
           name: 'get_result',
-          description: 'Get the current output and status of an AI agent process by PID. Returns the output from the agent including session_id (if applicable), along with process metadata.',
+          description: 'Get the current output and status of an AI agent process by PID. Defaults to a compact result shape; set verbose to true for full metadata and detailed parsed output.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -197,7 +197,7 @@ ${getSupportedModelsDescription()}
               },
               verbose: {
                 type: 'boolean',
-                description: 'Optional: If true, returns detailed execution information including tool usage history. Defaults to false.',
+                description: 'Optional: If true, returns the full result shape including metadata fields and detailed parsed output such as tool usage history. Defaults to false.',
               }
             },
             required: ['pid'],
@@ -205,7 +205,7 @@ ${getSupportedModelsDescription()}
         },
         {
           name: 'wait',
-          description: 'Wait for multiple AI agent processes to complete and return their results. Blocks until all specified PIDs finish or timeout occurs.',
+          description: 'Wait for multiple AI agent processes to complete and return their results. Defaults to compact result items; set verbose to true for full metadata and detailed parsed output.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -217,6 +217,10 @@ ${getSupportedModelsDescription()}
               timeout: {
                 type: 'number',
                 description: 'Optional: Maximum time to wait in seconds. Defaults to 180 (3 minutes).',
+              },
+              verbose: {
+                type: 'boolean',
+                description: 'Optional: If true, each result item uses the full result shape including metadata fields and detailed parsed output. Defaults to false.',
               },
             },
             required: ['pids'],
@@ -336,7 +340,8 @@ ${getSupportedModelsDescription()}
     try {
       const results = await this.processService.waitForProcesses(
         toolArguments.pids,
-        typeof toolArguments.timeout === 'number' ? toolArguments.timeout : 180
+        typeof toolArguments.timeout === 'number' ? toolArguments.timeout : 180,
+        !!toolArguments.verbose
       );
       return {
         content: [{

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -17,6 +17,7 @@ import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
 import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
+import { buildProcessResult } from './process-result.js';
 import type { AgentType, ProcessListItem } from './process-service.js';
 
 interface StoredProcess {
@@ -183,7 +184,7 @@ export class CliProcessService {
       }
     }
 
-    const response: any = {
+    return buildProcessResult({
       pid,
       agent: refreshed.toolType,
       status: refreshed.status,
@@ -192,27 +193,12 @@ export class CliProcessService {
       workFolder: refreshed.workFolder,
       prompt: refreshed.prompt,
       model: refreshed.model,
-    };
-
-    if (agentOutput) {
-      if (!verbose && agentOutput.tools) {
-        const { tools, ...rest } = agentOutput;
-        response.agentOutput = rest;
-      } else {
-        response.agentOutput = agentOutput;
-      }
-      if (agentOutput.session_id) {
-        response.session_id = agentOutput.session_id;
-      }
-    } else {
-      response.stdout = stdout;
-      response.stderr = stderr;
-    }
-
-    return response;
+      stdout,
+      stderr,
+    }, agentOutput, verbose);
   }
 
-  async waitForProcesses(pids: number[], timeoutSeconds = 180): Promise<any[]> {
+  async waitForProcesses(pids: number[], timeoutSeconds = 180, verbose = false): Promise<any[]> {
     const start = Date.now();
     for (const pid of pids) {
       this.readProcess(pid);
@@ -221,7 +207,7 @@ export class CliProcessService {
     while (true) {
       const statuses = pids.map((pid) => this.refreshStatus(this.readProcess(pid)).status);
       if (statuses.every((status) => status !== 'running')) {
-        return Promise.all(pids.map((pid) => this.getProcessResult(pid, false)));
+        return Promise.all(pids.map((pid) => this.getProcessResult(pid, verbose)));
       }
 
       if (Date.now() - start >= timeoutSeconds * 1000) {

--- a/src/process-result.ts
+++ b/src/process-result.ts
@@ -1,0 +1,79 @@
+import type { AgentType, ProcessStatus } from './process-service.js';
+
+interface ProcessResultContext {
+  pid: number;
+  agent: AgentType;
+  status: ProcessStatus;
+  exitCode?: number;
+  startTime: string;
+  workFolder: string;
+  prompt: string;
+  model?: string;
+  stdout: string;
+  stderr: string;
+}
+
+function compactAgentOutput(agentOutput: any): any | null {
+  if (!agentOutput || typeof agentOutput !== 'object') {
+    return null;
+  }
+
+  const { tools: _tools, ...rest } = agentOutput;
+  const compact = Object.fromEntries(Object.entries(rest).filter(([, value]) => value !== undefined && value !== null));
+  return Object.keys(compact).length > 0 ? compact : null;
+}
+
+function hasMeaningfulParsedOutput(agentOutput: any): boolean {
+  if (!agentOutput || typeof agentOutput !== 'object') {
+    return false;
+  }
+
+  return Object.entries(agentOutput).some(([key, value]) => {
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    if (key === 'session_id') {
+      return false;
+    }
+
+    if (key === 'tools') {
+      return Array.isArray(value) ? value.length > 0 : true;
+    }
+
+    return true;
+  });
+}
+
+export function buildProcessResult(context: ProcessResultContext, agentOutput: any, verbose = false): any {
+  const response: any = {
+    pid: context.pid,
+    agent: context.agent,
+    status: context.status,
+    exitCode: context.exitCode ?? null,
+    model: context.model ?? null,
+  };
+
+  if (verbose) {
+    response.startTime = context.startTime;
+    response.workFolder = context.workFolder;
+    response.prompt = context.prompt;
+  }
+
+  if (agentOutput?.session_id) {
+    response.session_id = agentOutput.session_id;
+  }
+
+  const shapedAgentOutput = verbose ? agentOutput : compactAgentOutput(agentOutput);
+
+  if (hasMeaningfulParsedOutput(shapedAgentOutput)) {
+    response.agentOutput = shapedAgentOutput;
+  }
+
+  if (!response.agentOutput) {
+    response.stdout = context.stdout;
+    response.stderr = context.stderr;
+  }
+
+  return response;
+}

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
+import { buildProcessResult } from './process-result.js';
 
 export type AgentType = 'claude' | 'codex' | 'gemini' | 'forge';
 export type ProcessStatus = 'running' | 'completed' | 'failed';
@@ -149,7 +150,7 @@ export class ProcessService {
       }
     }
 
-    const response: any = {
+    return buildProcessResult({
       pid,
       agent: process.toolType,
       status: process.status,
@@ -158,28 +159,12 @@ export class ProcessService {
       workFolder: process.workFolder,
       prompt: process.prompt,
       model: process.model,
-    };
-
-    if (agentOutput) {
-      if (!verbose && agentOutput.tools) {
-        const { tools, ...rest } = agentOutput;
-        response.agentOutput = rest;
-      } else {
-        response.agentOutput = agentOutput;
-      }
-
-      if (agentOutput.session_id) {
-        response.session_id = agentOutput.session_id;
-      }
-    } else {
-      response.stdout = process.stdout;
-      response.stderr = process.stderr;
-    }
-
-    return response;
+      stdout: process.stdout,
+      stderr: process.stderr,
+    }, agentOutput, verbose);
   }
 
-  async waitForProcesses(pids: number[], timeoutSeconds = 180): Promise<any[]> {
+  async waitForProcesses(pids: number[], timeoutSeconds = 180, verbose = false): Promise<any[]> {
     for (const pid of pids) {
       if (!this.processManager.has(pid)) {
         throw new Error(`Process with PID ${pid} not found`);
@@ -211,7 +196,7 @@ export class ProcessService {
 
     try {
       await Promise.race([Promise.all(waitPromises), timeoutPromise]);
-      return pids.map((pid) => this.getProcessResult(pid, false));
+      return pids.map((pid) => this.getProcessResult(pid, verbose));
     } finally {
       if (timeoutHandle) {
         clearTimeout(timeoutHandle);


### PR DESCRIPTION
## 関連Issue
Closes #29

## Summary

Add compact/verbose output shape to `get_result` and `wait` tools, and centralize result-building logic into a shared `process-result.ts` module.

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Refactoring
- [ ] docs: Documentation
- [ ] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- Added `src/process-result.ts`: shared `buildProcessResult` helper that enforces compact vs verbose output shape. Compact omits `startTime`, `workFolder`, `prompt`, and `agentOutput.tools`. Verbose includes all fields.
- Refactored `getProcessResult` in both `ProcessService` and `CliProcessService` to use `buildProcessResult`, removing duplicated inline logic.
- `waitForProcesses` now accepts a `verbose?: boolean` parameter in both service classes and passes it through to each `getProcessResult` call.
- MCP `wait` tool: added `verbose` input schema property and wired it to `waitForProcesses`.
- MCP `get_result` tool: updated description to reflect compact/verbose distinction.
- CLI `wait` command: `--verbose` flag is now forwarded to `waitForProcesses`; updated `WAIT_HELP_TEXT` and `RESULT_HELP_TEXT` accordingly.
- Updated README.md and README.ja.md with `--verbose` examples and compact/verbose behavior documentation.
- Updated tests: `app-cli.test.ts`, `cli-process-service.test.ts`, `mcp-contract.test.ts`, `process-management.test.ts` to cover compact default behavior and verbose opt-in.

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

Issue #29 reports that long prompts cause token limit issues because `prompt` is included in the default result shape. This PR addresses that by making `prompt`, `startTime`, and `workFolder` opt-in via `verbose: true`, keeping the default output compact.
