### PR TITLE
fix: 削除済み作業フォルダでのプロセス操作クラッシュを修正

### DIFF
--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -334,6 +334,111 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
     killSpy.mockRestore();
   });
 
+  it('lists processes without crashing when a tracked work folder has been deleted', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'deleted-project');
+    mkdirSync(workFolder, { recursive: true });
+
+    const pid = 45678;
+    const processDir = join(stateDir, 'cwds', encodeCwd(realpathSync(workFolder)), String(pid));
+    mkdirSync(processDir, { recursive: true });
+
+    writeFileSync(
+      join(processDir, 'meta.json'),
+      JSON.stringify({
+        pid,
+        prompt: 'deleted cwd',
+        workFolder,
+        toolType: 'claude',
+        startTime: new Date().toISOString(),
+        stdoutPath: join(processDir, 'stdout.log'),
+        stderrPath: join(processDir, 'stderr.log'),
+        status: 'running',
+      })
+    );
+
+    rmSync(workFolder, { recursive: true, force: true });
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: '/bin/sh',
+        codex: '/bin/sh',
+        gemini: '/bin/sh',
+        forge: '/bin/sh',
+      },
+    });
+
+    const killSpy = vi.spyOn(globalThis.process, 'kill').mockImplementation((target: number, signal?: string | number) => {
+      if (signal === 0 && target === pid) {
+        throw Object.assign(new Error('not running'), { code: 'ESRCH' });
+      }
+      return true;
+    });
+
+    const listed = await service.listProcesses();
+
+    expect(listed).toEqual([
+      {
+        pid,
+        agent: 'claude',
+        status: 'completed',
+      },
+    ]);
+    expect(JSON.parse(readFileSync(join(processDir, 'meta.json'), 'utf-8')).status).toBe('completed');
+    killSpy.mockRestore();
+  });
+
+  it('cleans up finished process directories even when their work folder has been deleted', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'deleted-finished-project');
+    mkdirSync(workFolder, { recursive: true });
+
+    const pid = 56789;
+    const cwdDir = join(stateDir, 'cwds', encodeCwd(realpathSync(workFolder)));
+    const processDir = join(cwdDir, String(pid));
+    mkdirSync(processDir, { recursive: true });
+
+    writeFileSync(
+      join(processDir, 'meta.json'),
+      JSON.stringify({
+        pid,
+        prompt: 'done',
+        workFolder,
+        toolType: 'claude',
+        startTime: new Date().toISOString(),
+        stdoutPath: join(processDir, 'stdout.log'),
+        stderrPath: join(processDir, 'stderr.log'),
+        status: 'completed',
+      })
+    );
+
+    rmSync(workFolder, { recursive: true, force: true });
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: '/bin/sh',
+        codex: '/bin/sh',
+        gemini: '/bin/sh',
+        forge: '/bin/sh',
+      },
+    });
+
+    const result = await service.cleanupProcesses();
+
+    expect(result).toEqual({
+      removed: 1,
+      message: 'Removed 1 processes',
+    });
+    expect(existsSync(processDir)).toBe(false);
+    expect(existsSync(cwdDir)).toBe(false);
+  });
+
   it('cleans up completed and failed process directories but preserves running ones', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
     tempDirs.push(root);

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -12,7 +12,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
@@ -24,6 +24,7 @@ interface StoredProcess {
   pid: number;
   prompt: string;
   workFolder: string;
+  cwdKey?: string;
   model?: string;
   toolType: AgentType;
   startTime: string;
@@ -128,6 +129,7 @@ export class CliProcessService {
         pid,
         prompt: cmd.prompt,
         workFolder: cmd.cwd,
+        cwdKey: this.resolveCwdKey(cmd.cwd),
         model: options.model,
         toolType: cmd.agent,
         startTime: new Date().toISOString(),
@@ -260,7 +262,7 @@ export class CliProcessService {
         continue;
       }
 
-      const processDir = this.resolveProcessDir(refreshed.workFolder, refreshed.pid);
+      const processDir = this.resolveStoredProcessDir(refreshed);
       if (existsSync(processDir)) {
         rmSync(processDir, { recursive: true, force: true });
         removed++;
@@ -304,11 +306,15 @@ export class CliProcessService {
   }
 
   private parseProcessFile(metaPath: string): StoredProcess {
-    return JSON.parse(readFileSync(metaPath, 'utf-8')) as StoredProcess;
+    const process = JSON.parse(readFileSync(metaPath, 'utf-8')) as StoredProcess;
+    if (!process.cwdKey) {
+      process.cwdKey = basename(dirname(dirname(metaPath)));
+    }
+    return process;
   }
 
   private writeProcess(process: StoredProcess): void {
-    const processDir = this.resolveProcessDir(process.workFolder, process.pid);
+    const processDir = this.resolveStoredProcessDir(process);
     mkdirSync(processDir, { recursive: true });
     writeFileSync(this.resolveMetaPath(processDir), JSON.stringify(process, null, 2));
   }
@@ -333,7 +339,18 @@ export class CliProcessService {
   }
 
   private resolveProcessDir(cwd: string, pid: number): string {
-    return join(this.resolveCwdsDir(), normalizeCwdForStorage(realpathSync(cwd)), String(pid));
+    return join(this.resolveCwdsDir(), this.resolveCwdKey(cwd), String(pid));
+  }
+
+  private resolveStoredProcessDir(process: StoredProcess): string {
+    if (!process.cwdKey) {
+      process.cwdKey = this.resolveCwdKey(process.workFolder);
+    }
+    return join(this.resolveCwdsDir(), process.cwdKey, String(process.pid));
+  }
+
+  private resolveCwdKey(cwd: string): string {
+    return normalizeCwdForStorage(realpathSync(cwd));
   }
 
   private resolveMetaPath(processDir: string): string {


### PR DESCRIPTION
Closes #30

## Summary

Fix crash when listing or cleaning up processes whose work folder (cwd) has been deleted. The root cause was that `realpathSync(cwd)` throws when the directory no longer exists. The fix stores the resolved `cwdKey` in the process metadata at creation time, so subsequent operations can look up the process directory without touching the (possibly deleted) work folder.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Refactoring
- [ ] docs: Documentation
- [ ] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- Added `cwdKey` field to `StoredProcess` interface to store the normalized cwd path at process creation time
- Added `resolveCwdKey(cwd)` method that wraps `normalizeCwdForStorage(realpathSync(cwd))`
- Added `resolveStoredProcessDir(process)` method that uses `process.cwdKey` instead of calling `realpathSync` on `workFolder` (which may have been deleted)
- Updated `parseProcessFile` to back-fill `cwdKey` from the on-disk path for processes created before this change
- Updated `writeProcess` and cleanup logic to use `resolveStoredProcessDir`
- Added two new test cases covering `listProcesses` and `cleanupProcesses` when the work folder has been deleted

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

<!-- Any additional context for reviewers -->
Back-fill logic in `parseProcessFile` (`basename(dirname(dirname(metaPath)))`) ensures backward compatibility with process state files that were persisted before `cwdKey` was added.
