### PR TITLE
feat: OpenCode CLIを新しいAIバックエンドとして追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 
 > **📦 パッケージ移行のお知らせ**: 本パッケージは旧名 `@mkxultra/claude-code-mcp` から `ai-cli-mcp` に名称変更されました。これは、複数のAI CLIツールのサポート拡大を反映したものです。
 
-AI CLIツール（Claude, Codex, Gemini, Forge）をバックグラウンドプロセスとして実行し、権限処理を自動化するMCP（Model Context Protocol）サーバーです。
+AI CLIツール（Claude, Codex, Gemini, Forge, OpenCode）をバックグラウンドプロセスとして実行し、権限処理を自動化するMCP（Model Context Protocol）サーバーです。
 
 Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦戦していることに気づいたことはありませんか？このサーバーは、強力な統合 `run` ツールを提供し、複数のAIエージェントを活用してコーディングタスクをより効果的に処理できるようにします。
 
@@ -21,11 +21,13 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - 自動承認モードでCodex CLIを実行（`--full-auto` を使用）
 - 自動承認モードでGemini CLIを実行（`-y` を使用）
 - Forge CLI を非対話モードで実行（`forge -C <workFolder> -p <prompt>` を使用）
+- OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
     - Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
     - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
     - Forge (`forge`)
+    - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
 - PID追跡によるバックグラウンドプロセスの管理
 - ツールからの構造化された出力の解析と返却
 
@@ -67,6 +69,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - **Codex CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
 - **Gemini CLI**（オプション）: インストール済みで、ログインなどの初期設定が完了していること。
 - **Forge CLI**（オプション）: インストール済みで、初期設定が完了していること。
+- **OpenCode**（オプション）: インストール済みで、設定が完了していること。この統合では `opencode run --format json` を使用し、明示的なモデル指定は `ai-cli models` が公開する `oc-<provider/model>` 構文に従います。
 
 ## インストールと使い方
 
@@ -116,6 +119,8 @@ npm install -g ai-cli-mcp
 ai-cli doctor
 ai-cli models
 ai-cli run --cwd "$PWD" --model sonnet --prompt "summarize this repository"
+ai-cli run --cwd "$PWD" --model opencode --prompt "OpenCode のデフォルト設定でこのリポジトリを要約して"
+ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --session-id ses_123 --prompt "明示モデル付きでこの OpenCode セッションを続けて"
 ai-cli ps
 ai-cli result 12345
 ai-cli result 12345 --verbose
@@ -132,6 +137,7 @@ ai-cli-mcp
 
 ```bash
 npx -y --package ai-cli-mcp@latest ai-cli run --cwd "$PWD" --model sonnet --prompt "hello"
+npx -y --package ai-cli-mcp@latest ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "OpenCode で hello"
 ```
 
 ## 重要な初回セットアップ
@@ -185,6 +191,8 @@ macOSでは、これらのツールを初めて実行する際にフォルダへ
 ai-cli doctor
 ai-cli models
 ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
+ai-cli run --cwd "$PWD" --model opencode --session-id ses_existing --prompt "この OpenCode セッションを継続して"
+ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "明示的な OpenCode モデルで実行"
 ai-cli ps
 ai-cli wait 12345
 ai-cli wait 12345 --verbose
@@ -194,6 +202,13 @@ ai-cli cleanup
 ```
 
 `run` の作業ディレクトリ指定は `--cwd` が基本です。互換性のために `--workFolder` / `--work-folder` も受け付けます。
+
+OpenCode のモデル指定は次の 2 つを受け付けます。
+
+- `opencode`: OpenCode 側で設定されたデフォルトモデルを使用
+- `oc-<provider/model>`: 明示的な OpenCode の provider/model を指定。例: `oc-openai/gpt-5.4`
+
+`ai-cli models` は OpenCode を機械可読に `opencode: ["opencode"]` と `dynamicModelBackends.opencode` で公開します。実際に利用可能なバックエンドネイティブなモデル一覧は `opencode models` で確認してください。
 
 `doctor` は CLI バイナリの存在確認と path 解決だけを行います。ログイン状態や利用規約同意までは確認しません。
 
@@ -210,12 +225,13 @@ ai-cli cleanup
 - `meta.json`
 - `stdout.log`
 - `stderr.log`
+- `exit-status.json`（detached な OpenCode 実行用）
 
 完了済み・失敗済みの実行は `ai-cli cleanup` で削除できます。`running` のものは保持されます。
 
 ## 既知の制約
 
-detached 実行された `ai-cli` の自然終了 exit code は、まだ永続化していません。そのため、CLI は出力と running/completed 状態は返せますが、自然終了したバックグラウンド実行の `exitCode` は現時点では保証しません。
+detached 実行された `ai-cli` では、OpenCode バックエンドに限り自然終了時の exit status を永続化します。そのため OpenCode の失敗終了は非ゼロ exit code を含めて `failed` として扱われ、結果では生の `stdout` / `stderr` を保持します。一方、他の detached バックエンドでは従来どおり、より広い exit-status 追跡が追加されるまでは自然終了した実行が信頼できる exit code なしで `completed` と見なされる制約が残ります。
 
 ## MCPクライアントへの接続
 
@@ -229,7 +245,7 @@ detached 実行された `ai-cli` の自然終了 exit code は、まだ永続�
 
 ### `run`
 
-Claude CLI、Codex CLI、Gemini CLI、または Forge CLI を使用してプロンプトを実行します。モデル名に基づいて適切なCLIが自動的に選択されます。
+Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用してプロンプトを実行します。モデル名に基づいて適切なCLIが自動的に選択されます。
 
 **引数:**
 - `prompt` (string, 任意): AIエージェントに送信するプロンプト。`prompt` または `prompt_file` のいずれかが必須です。
@@ -241,8 +257,9 @@ Claude CLI、Codex CLI、Gemini CLI、または Forge CLI を使用してプロ�
     - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
     - Forge: `forge`
-- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。Forge では `reasoning_effort` はサポートしません。
-- `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。対応モデル: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview, forge。
+    - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー
+- `reasoning_effort` (string, 任意): Claude と Codex の推論制御。Claude では `--effort` を使います（許容値: "low", "medium", "high"）。Codex では `model_reasoning_effort` を使います（許容値: "low", "medium", "high", "xhigh"）。Gemini、Forge、OpenCode では `reasoning_effort` はサポートしません。
+- `session_id` (string, 任意): 以前のセッションを再開するためのセッションID。Claude、Codex、Gemini、Forge、OpenCode でサポートされます。OpenCode は `--session` による in-place resume で再開し、`oc-<provider/model>` の明示指定と併用できます。
 
 ### `wait`
 
@@ -311,6 +328,7 @@ npm run test:e2e
 - `CODEX_CLI_NAME`: Codex CLIのバイナリ名または絶対パスを上書き（デフォルト: `codex`）
 - `GEMINI_CLI_NAME`: Gemini CLIのバイナリ名または絶対パスを上書き（デフォルト: `gemini`）
 - `FORGE_CLI_NAME`: Forge CLIのバイナリ名または絶対パスを上書き（デフォルト: `forge`）
+- `OPENCODE_CLI_NAME`: OpenCode CLIのバイナリ名または絶対パスを上書き（デフォルト: `opencode`）
 - `MCP_CLAUDE_DEBUG`: デバッグログを有効化（`true` に設定すると詳細な出力が表示されます）
 
 **CLI名の指定方法:**
@@ -329,7 +347,8 @@ npm run test:e2e
       ],
       "env": {
         "CLAUDE_CLI_NAME": "claude-custom",
-        "CODEX_CLI_NAME": "codex-custom"
+        "CODEX_CLI_NAME": "codex-custom",
+        "OPENCODE_CLI_NAME": "opencode-custom"
       }
     },
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **📦 Package Migration Notice**: This package was formerly `@mkxultra/claude-code-mcp` and has been renamed to `ai-cli-mcp` to reflect its expanded support for multiple AI CLI tools.
 
-An MCP (Model Context Protocol) server that allows running AI CLI tools (Claude, Codex, Gemini, and Forge) in background processes with automatic permission handling.
+An MCP (Model Context Protocol) server that allows running AI CLI tools (Claude, Codex, Gemini, Forge, and OpenCode) in background processes with automatic permission handling.
 
 Did you notice that Cursor sometimes struggles with complex, multi-step edits or operations? This server, with its powerful unified `run` tool, enables multiple AI agents to handle your coding tasks more effectively.
 
@@ -23,7 +23,8 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Execute Codex CLI with automatic approval mode (using `--full-auto`)
 - Execute Gemini CLI with automatic approval mode (using `-y`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), and Forge (`forge`)
+- Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -65,6 +66,7 @@ The only prerequisite is that the AI CLI tools you want to use are locally insta
 - **Codex CLI** (Optional): Installed and initial setup (login etc.) completed.
 - **Gemini CLI** (Optional): Installed and initial setup (login etc.) completed.
 - **Forge CLI** (Optional): Installed and initial setup completed.
+- **OpenCode** (Optional): Installed and configured. This integration uses `opencode run --format json`, and explicit provider/model selection follows the `oc-<provider/model>` wrapper syntax exposed by `ai-cli models`.
 
 ## Installation & Usage
 
@@ -114,6 +116,8 @@ Examples:
 ai-cli doctor
 ai-cli models
 ai-cli run --cwd "$PWD" --model sonnet --prompt "summarize this repository"
+ai-cli run --cwd "$PWD" --model opencode --prompt "summarize this repository with OpenCode defaults"
+ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --session-id ses_123 --prompt "continue this session with an explicit OpenCode model"
 ai-cli ps
 ai-cli result 12345
 ai-cli result 12345 --verbose
@@ -130,6 +134,7 @@ Because the published package name is still `ai-cli-mcp`, the shortest `npx` for
 
 ```bash
 npx -y --package ai-cli-mcp@latest ai-cli run --cwd "$PWD" --model sonnet --prompt "hello"
+npx -y --package ai-cli-mcp@latest ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "hello from OpenCode"
 ```
 
 ## Important First-Time Setup
@@ -183,6 +188,8 @@ Example flow:
 ai-cli doctor
 ai-cli models
 ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
+ai-cli run --cwd "$PWD" --model opencode --session-id ses_existing --prompt "continue this OpenCode session"
+ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "run with an explicit OpenCode backend model"
 ai-cli ps
 ai-cli wait 12345
 ai-cli wait 12345 --verbose
@@ -192,6 +199,13 @@ ai-cli cleanup
 ```
 
 `run` accepts `--cwd` as the primary working-directory flag and also accepts the older aliases `--workFolder` / `--work-folder` for compatibility.
+
+OpenCode model selection accepts either:
+
+- `opencode` for the CLI's configured default model
+- `oc-<provider/model>` for an explicit OpenCode provider/model, for example `oc-openai/gpt-5.4`
+
+`ai-cli models` exposes OpenCode machine-readably via `opencode: ["opencode"]` plus `dynamicModelBackends.opencode`, which points users to `opencode models` for backend-native discovery.
 
 `doctor` checks only binary existence and path resolution. It does not verify login state or terms acceptance.
 
@@ -208,12 +222,13 @@ Each PID directory contains:
 - `meta.json`
 - `stdout.log`
 - `stderr.log`
+- `exit-status.json` for detached OpenCode runs
 
 Use `ai-cli cleanup` to remove completed and failed runs. Running processes are preserved.
 
 ## Known Limitation
 
-Detached `ai-cli` runs do not currently persist natural process exit codes. As a result, the CLI can report process output and running/completed state, but it does not yet guarantee `exitCode` for naturally finished background runs.
+Detached `ai-cli` runs persist natural exit status for OpenCode-backed runs, including failed exit codes used to preserve raw OpenCode stdout/stderr in result output. Other detached backends still keep the pre-existing limitation: naturally finished runs may be surfaced as completed without a reliable persisted exit code until broader exit tracking is added.
 
 ## Connecting to Your MCP Client
 
@@ -227,7 +242,7 @@ This server exposes the following tools:
 
 ### `run`
 
-Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, or Forge CLI. The appropriate CLI is automatically selected based on the model name.
+Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCode. The appropriate CLI is automatically selected based on the model name.
 
 **Arguments:**
 - `prompt` (string, optional): The prompt to send to the AI agent. Either `prompt` or `prompt_file` is required.
@@ -239,8 +254,9 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, or Forge CLI. The app
 - Codex: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 - Forge: `forge`
-- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh"). Forge does not support `reasoning_effort`.
-- `session_id` (string, optional): Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview, forge.
+- OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`
+- `reasoning_effort` (string, optional): Reasoning control for Claude and Codex. Claude uses `--effort` (allowed: "low", "medium", "high"). Codex uses `model_reasoning_effort` (allowed: "low", "medium", "high", "xhigh"). Gemini, Forge, and OpenCode do not support `reasoning_effort`.
+- `session_id` (string, optional): Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in place via `--session` and may also be combined with an explicit `oc-<provider/model>` selection.
 
 ### `wait`
 
@@ -295,6 +311,7 @@ Normally not required, but useful for customizing CLI paths or debugging.
 - `CODEX_CLI_NAME`: Override the Codex CLI binary name or provide an absolute path (default: `codex`)
 - `GEMINI_CLI_NAME`: Override the Gemini CLI binary name or provide an absolute path (default: `gemini`)
 - `FORGE_CLI_NAME`: Override the Forge CLI binary name or provide an absolute path (default: `forge`)
+- `OPENCODE_CLI_NAME`: Override the OpenCode CLI binary name or provide an absolute path (default: `opencode`)
 - `MCP_CLAUDE_DEBUG`: Enable debug logging (set to `true` for verbose output)
 
 **CLI Name Specification:**
@@ -313,7 +330,8 @@ Normally not required, but useful for customizing CLI paths or debugging.
       ],
       "env": {
         "CLAUDE_CLI_NAME": "claude-custom",
-        "CODEX_CLI_NAME": "codex-custom"
+        "CODEX_CLI_NAME": "codex-custom",
+        "OPENCODE_CLI_NAME": "opencode-custom"
       }
     },
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-cli-mcp",
   "version": "2.14.1",
   "mcpName": "io.github.mkXultra/ai-cli-mcp",
-  "description": "MCP server for AI CLI tools (Claude, Codex, Gemini, and Forge) with background process management",
+  "description": "MCP server for AI CLI tools (Claude, Codex, Gemini, Forge, and OpenCode) with background process management",
   "author": "mkXultra",
   "license": "MIT",
   "main": "dist/server.js",

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -236,12 +236,22 @@ describe('ai-cli app', () => {
     const stderr = vi.fn();
 
     const exitCode = await runCli(['models'], { stdout, stderr });
+    const payload = JSON.parse(stdout.mock.calls[0][0]);
 
     expect(exitCode).toBe(0);
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"aliases"'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"claude-ultra"'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"gpt-5.4"'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"forge"'));
+    expect(payload.aliases).toEqual(expect.any(Array));
+    expect(payload.claude).toContain('sonnet');
+    expect(payload.codex).toContain('gpt-5.4');
+    expect(payload.forge).toEqual(['forge']);
+    expect(payload.opencode).toEqual(['opencode']);
+    expect(payload.dynamicModelBackends).toEqual({
+      opencode: {
+        explicitPrefix: 'oc-',
+        explicitPattern: 'oc-<provider/model>',
+        discoveryCommand: 'opencode models',
+        modelsAreDynamic: true,
+      },
+    });
     expect(stderr).not.toHaveBeenCalled();
   });
 
@@ -270,6 +280,12 @@ describe('ai-cli app', () => {
       forge: {
         configuredCommand: 'forge',
         resolvedPath: '/tmp/bin/forge',
+        available: true,
+        lookup: 'path',
+      },
+      opencode: {
+        configuredCommand: 'opencode',
+        resolvedPath: '/tmp/bin/opencode',
         available: true,
         lookup: 'path',
       },
@@ -307,6 +323,8 @@ describe('ai-cli app', () => {
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.2-codex'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-2.5-pro'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('forge'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('opencode'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('oc-openai/gpt-5.4'));
     expect(stderr).not.toHaveBeenCalled();
   });
 
@@ -355,6 +373,7 @@ describe('ai-cli app', () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toHaveBeenCalledWith(DOCTOR_HELP_TEXT);
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('OpenCode'));
     expect(stderr).not.toHaveBeenCalled();
   });
 
@@ -366,6 +385,7 @@ describe('ai-cli app', () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toHaveBeenCalledWith(DOCTOR_HELP_TEXT);
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('OpenCode'));
     expect(stderr).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/cli-bin-smoke.test.ts
+++ b/src/__tests__/cli-bin-smoke.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -24,6 +24,62 @@ afterEach(() => {
   }
 });
 
+describe('cli helper entrypoint smoke', () => {
+  it('prints help for cli.run with OpenCode examples', () => {
+    const output = execFileSync(
+      'node',
+      ['--import', 'tsx', 'src/cli.ts', '--help'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: process.env,
+      }
+    );
+
+    expect(output).toContain('Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]');
+    expect(output).toContain('opencode');
+    expect(output).toContain('oc-openai/gpt-5.4');
+    expect(output).toContain('OpenCode');
+    expect(output).toContain('npm run -s cli.run.parse -- --agent opencode < raw.txt');
+  });
+
+  it('prints help for cli.run.parse with OpenCode agent support', () => {
+    const output = execFileSync(
+      'node',
+      ['--import', 'tsx', 'src/cli-parse.ts', '--help'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: process.env,
+      }
+    );
+
+    expect(output).toContain('Usage: npm run -s cli.run.parse -- --agent <claude|codex|gemini|forge|opencode>');
+    expect(output).toContain('Agent type: claude, codex, gemini, forge, or opencode');
+    expect(output).toContain('npm run -s cli.run.parse -- --agent opencode < raw.txt');
+  });
+
+  it('parses OpenCode NDJSON through cli.run.parse', () => {
+    const output = execFileSync(
+      'node',
+      ['--import', 'tsx', 'src/cli-parse.ts', '--agent', 'opencode'],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: process.env,
+        input: '{"type":"step_start","sessionID":"ses_cli_parse"}\n{"type":"text","sessionID":"ses_cli_parse","part":{"type":"text","text":"Hello from cli.parse"}}\n{"type":"step_finish","sessionID":"ses_cli_parse","part":{"type":"step-finish","tokens":{"total":9},"cost":1}}\n',
+      }
+    );
+
+    expect(JSON.parse(output)).toEqual({
+      message: 'Hello from cli.parse',
+      session_id: 'ses_cli_parse',
+      tokens: { total: 9 },
+      cost: 1,
+    });
+  });
+});
+
 describe('ai-cli entrypoint smoke', () => {
   it('prints doctor output for the ai-cli entrypoint', () => {
     const fakeBinDir = makeTempDir('ai-cli-bin-');
@@ -31,6 +87,7 @@ describe('ai-cli entrypoint smoke', () => {
     writeExecutable(fakeBinDir, 'codex');
     writeExecutable(fakeBinDir, 'gemini');
     writeExecutable(fakeBinDir, 'forge');
+    writeExecutable(fakeBinDir, 'opencode');
 
     const output = execFileSync(
       'node',
@@ -45,6 +102,7 @@ describe('ai-cli entrypoint smoke', () => {
           CODEX_CLI_NAME: 'codex',
           GEMINI_CLI_NAME: 'gemini',
           FORGE_CLI_NAME: 'forge',
+          OPENCODE_CLI_NAME: 'opencode',
         },
       }
     );
@@ -53,6 +111,7 @@ describe('ai-cli entrypoint smoke', () => {
     expect(output).toContain('"codex"');
     expect(output).toContain('"gemini"');
     expect(output).toContain('"forge"');
+    expect(output).toContain('"opencode"');
     expect(output).toContain('"available": true');
   });
 
@@ -71,5 +130,7 @@ describe('ai-cli entrypoint smoke', () => {
     expect(output).toContain('--model <model>');
     expect(output).toContain('claude-ultra');
     expect(output).toContain('forge');
+    expect(output).toContain('opencode');
+    expect(output).toContain('oc-openai/gpt-5.4');
   });
 });

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -23,6 +23,7 @@ const DEFAULT_CLI_PATHS = {
   codex: '/usr/bin/codex',
   gemini: '/usr/bin/gemini',
   forge: '/usr/bin/forge',
+  opencode: '/usr/bin/opencode',
 };
 
 describe('cli-builder', () => {
@@ -102,6 +103,15 @@ describe('cli-builder', () => {
     it('should reject reasoning_effort for forge explicitly', () => {
       expect(() => getReasoningEffort('forge', 'high')).toThrow(
         'reasoning_effort is not supported for forge.'
+      );
+    });
+
+    it('should reject reasoning_effort for opencode explicitly', () => {
+      expect(() => getReasoningEffort('opencode', 'high')).toThrow(
+        'reasoning_effort is not supported for opencode.'
+      );
+      expect(() => getReasoningEffort('oc-openai/gpt-5.4', 'high')).toThrow(
+        'reasoning_effort is not supported for opencode.'
       );
     });
   });
@@ -409,43 +419,129 @@ describe('cli-builder', () => {
       });
     });
 
-    describe('forge agent', () => {
-      it('should build forge command without model flags', () => {
+    describe('opencode agent', () => {
+      it('should build default opencode command without --model', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
-          model: 'forge',
+          model: 'opencode',
           cliPaths: DEFAULT_CLI_PATHS,
         });
 
-        expect(cmd.agent).toBe('forge');
-        expect(cmd.cliPath).toBe('/usr/bin/forge');
-        expect(cmd.resolvedModel).toBe('forge');
-        expect(cmd.args).toEqual(['-C', '/tmp', '-p', 'test']);
+        expect(cmd.agent).toBe('opencode');
+        expect(cmd.cliPath).toBe('/usr/bin/opencode');
+        expect(cmd.cwd).toBe('/tmp');
+        expect(cmd.args).toEqual(['run', '--format', 'json', '--dir', '/tmp', 'test']);
+        expect(cmd.args).not.toContain('--model');
       });
 
-      it('should map session_id to --conversation-id for forge', () => {
+      it('should route valid explicit OpenCode model syntax', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
-          model: 'forge',
-          session_id: 'forge-conv-123',
+          model: 'oc-openai/gpt-5.4',
           cliPaths: DEFAULT_CLI_PATHS,
         });
 
-        expect(cmd.args).toEqual(['-C', '/tmp', '--conversation-id', 'forge-conv-123', '-p', 'test']);
+        expect(cmd.agent).toBe('opencode');
+        expect(cmd.resolvedModel).toBe('oc-openai/gpt-5.4');
+        expect(cmd.args).toEqual([
+          'run',
+          '--format',
+          'json',
+          '--dir',
+          '/tmp',
+          '--model',
+          'openai/gpt-5.4',
+          'test',
+        ]);
       });
 
-      it('should reject reasoning_effort for forge in command building', () => {
+      it.each([
+        'oc-',
+        'oc-openai',
+        'oc-/gpt-5.4',
+        'oc-openai/',
+      ])('should reject invalid explicit OpenCode syntax: %s', (model) => {
         expect(() =>
           buildCliCommand({
             prompt: 'test',
             workFolder: '/tmp',
-            model: 'forge',
+            model,
+            cliPaths: DEFAULT_CLI_PATHS,
+          })
+        ).toThrow('Invalid OpenCode model. Expected exact syntax oc-<provider/model>.');
+      });
+
+      it.each([' oc-openai/gpt-5.4', 'oc-openai/gpt-5.4 '])(
+        'should reject explicit OpenCode models with surrounding whitespace: %s',
+        (model) => {
+          expect(() =>
+            buildCliCommand({
+              prompt: 'test',
+              workFolder: '/tmp',
+              model,
+              cliPaths: DEFAULT_CLI_PATHS,
+            })
+          ).toThrow('Invalid OpenCode model. Expected exact syntax oc-<provider/model>.');
+        }
+      );
+
+      it('should reject reasoning_effort for OpenCode in command building', () => {
+        expect(() =>
+          buildCliCommand({
+            prompt: 'test',
+            workFolder: '/tmp',
+            model: 'opencode',
             reasoning_effort: 'high',
             cliPaths: DEFAULT_CLI_PATHS,
           })
-        ).toThrow('reasoning_effort is not supported for forge.');
+        ).toThrow('reasoning_effort is not supported for opencode.');
+      });
+
+      it('should build resumed default OpenCode command', () => {
+        const cmd = buildCliCommand({
+          prompt: 'resume prompt',
+          workFolder: '/tmp',
+          model: 'opencode',
+          session_id: 'ses-123',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toEqual([
+          'run',
+          '--format',
+          'json',
+          '--dir',
+          '/tmp',
+          '--session',
+          'ses-123',
+          'resume prompt',
+        ]);
+        expect(cmd.args).not.toContain('--model');
+      });
+
+      it('should build resumed explicit OpenCode command', () => {
+        const cmd = buildCliCommand({
+          prompt: 'resume prompt',
+          workFolder: '/tmp',
+          model: 'oc-openai/gpt-5.4',
+          session_id: 'ses-456',
+          cliPaths: DEFAULT_CLI_PATHS,
+        });
+
+        expect(cmd.args).toEqual([
+          'run',
+          '--format',
+          'json',
+          '--dir',
+          '/tmp',
+          '--session',
+          'ses-456',
+          '--model',
+          'openai/gpt-5.4',
+          'resume prompt',
+        ]);
       });
     });
   });

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { CliProcessService } from '../cli-process-service.js';
+import { createOpenCodeMock } from './utils/opencode-mock.js';
 
 function createMockCliScript(dir: string, name: string, options: { ignoreSigterm?: boolean } = {}): string {
   const scriptPath = join(dir, name);
@@ -66,6 +67,7 @@ describe('CliProcessService', () => {
         codex: scriptPath,
         gemini: scriptPath,
         forge: scriptPath,
+        opencode: scriptPath,
       },
     });
 
@@ -145,6 +147,7 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
         codex: scriptPath,
         gemini: scriptPath,
         forge: scriptPath,
+        opencode: scriptPath,
       },
     });
 
@@ -255,6 +258,7 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
         codex: scriptPath,
         gemini: scriptPath,
         forge: scriptPath,
+        opencode: scriptPath,
       },
     });
 
@@ -294,6 +298,7 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
         codex: '/bin/sh',
         gemini: '/bin/sh',
         forge: '/bin/sh',
+        opencode: '/bin/sh',
       },
     });
 
@@ -368,6 +373,7 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
         codex: '/bin/sh',
         gemini: '/bin/sh',
         forge: '/bin/sh',
+        opencode: '/bin/sh',
       },
     });
 
@@ -426,6 +432,7 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
         codex: '/bin/sh',
         gemini: '/bin/sh',
         forge: '/bin/sh',
+        opencode: '/bin/sh',
       },
     });
 
@@ -502,6 +509,7 @@ printf '%s\n' '{"type":"system","session_id":"session-cli-1"}'
         codex: '/bin/sh',
         gemini: '/bin/sh',
         forge: '/bin/sh',
+        opencode: '/bin/sh',
       },
     });
 
@@ -564,6 +572,7 @@ Forge assistant reply
         codex: '/bin/sh',
         gemini: '/bin/sh',
         forge: '/bin/sh',
+        opencode: '/bin/sh',
       },
     });
 
@@ -573,6 +582,109 @@ Forge assistant reply
     expect(result.agentOutput).toEqual({
       message: 'Forge assistant reply',
       session_id: 'forge-conv-1',
+    });
+  });
+
+  it('parses successful OpenCode detached runs from stdout only', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'opencode-project');
+    mkdirSync(workFolder, { recursive: true });
+    const argsLogPath = join(root, 'opencode-args.log');
+    const { scriptPath } = createOpenCodeMock(root, { argsLogPath });
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: '/bin/sh',
+        codex: '/bin/sh',
+        gemini: '/bin/sh',
+        forge: '/bin/sh',
+        opencode: scriptPath,
+      },
+    });
+
+    const runResult = await service.startProcess({
+      prompt: 'hello opencode',
+      cwd: workFolder,
+      model: 'opencode',
+    });
+
+    const waited = await service.waitForProcesses([runResult.pid], 5);
+    expect(waited).toHaveLength(1);
+    expect(waited[0]).toMatchObject({
+      pid: runResult.pid,
+      agent: 'opencode',
+      status: 'completed',
+      exitCode: 0,
+      model: 'opencode',
+      session_id: 'ses-opencode-default',
+      agentOutput: {
+        message: 'Initial: hello opencode',
+        session_id: 'ses-opencode-default',
+        tokens: { total: 11833 },
+        cost: 0,
+      },
+    });
+    expect(waited[0]).not.toHaveProperty('stdout');
+    expect(waited[0]).not.toHaveProperty('stderr');
+    expect(readFileSync(argsLogPath, 'utf8')).toContain(`--dir ${workFolder}`);
+  });
+
+  it('preserves raw stdout and stderr for failed detached OpenCode runs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'opencode-fail-project');
+    mkdirSync(workFolder, { recursive: true });
+    const { scriptPath } = createOpenCodeMock(root);
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: '/bin/sh',
+        codex: '/bin/sh',
+        gemini: '/bin/sh',
+        forge: '/bin/sh',
+        opencode: scriptPath,
+      },
+    });
+
+    const runResult = await service.startProcess({
+      prompt: 'please fail',
+      cwd: workFolder,
+      model: 'oc-openai/gpt-5.4',
+    });
+
+    const [compactResult] = await service.waitForProcesses([runResult.pid], 5);
+    expect(compactResult).toMatchObject({
+      pid: runResult.pid,
+      agent: 'opencode',
+      status: 'failed',
+      exitCode: 7,
+      model: 'oc-openai/gpt-5.4',
+      session_id: 'ses-opencode-default',
+      stdout: expect.stringContaining('Partial failure output'),
+      stderr: expect.stringContaining('OpenCode failed for openai/gpt-5.4'),
+    });
+    expect(compactResult).not.toHaveProperty('agentOutput');
+
+    const verboseResult = await service.getProcessResult(runResult.pid, true);
+    expect(verboseResult).toMatchObject({
+      pid: runResult.pid,
+      agent: 'opencode',
+      status: 'failed',
+      exitCode: 7,
+      session_id: 'ses-opencode-default',
+      stdout: expect.stringContaining('Partial failure output'),
+      stderr: expect.stringContaining('OpenCode failed for openai/gpt-5.4'),
+      agentOutput: {
+        message: 'Partial failure output',
+        session_id: 'ses-opencode-default',
+        tokens: { total: 42 },
+        cost: 0,
+      },
     });
   });
 });

--- a/src/__tests__/cli-utils.test.ts
+++ b/src/__tests__/cli-utils.test.ts
@@ -20,6 +20,7 @@ describe('cli-utils doctor status', () => {
     delete process.env.CODEX_CLI_NAME;
     delete process.env.GEMINI_CLI_NAME;
     delete process.env.FORGE_CLI_NAME;
+    delete process.env.OPENCODE_CLI_NAME;
     process.env.PATH = '/mock/bin:/usr/bin';
   });
 
@@ -51,6 +52,12 @@ describe('cli-utils doctor status', () => {
       available: false,
       lookup: 'path',
     });
+    expect(status.opencode).toEqual({
+      configuredCommand: 'opencode',
+      resolvedPath: null,
+      available: false,
+      lookup: 'path',
+    });
   });
 
   it('does not mark non-executable PATH entries as available', async () => {
@@ -69,6 +76,12 @@ describe('cli-utils doctor status', () => {
     });
     expect(status.forge).toEqual({
       configuredCommand: 'forge',
+      resolvedPath: null,
+      available: false,
+      lookup: 'path',
+    });
+    expect(status.opencode).toEqual({
+      configuredCommand: 'opencode',
       resolvedPath: null,
       available: false,
       lookup: 'path',
@@ -162,5 +175,26 @@ describe('cli-utils doctor status', () => {
       lookup: 'env',
     });
     expect(findForgeCli()).toBe('forge-custom');
+  });
+
+  it('supports OpenCode lookup via OPENCODE_CLI_NAME', async () => {
+    process.env.OPENCODE_CLI_NAME = 'opencode-custom';
+    mockAccessSync.mockImplementation((filePath) => {
+      if (filePath === '/mock/bin/opencode-custom') {
+        return undefined;
+      }
+      throw new Error('not executable');
+    });
+
+    const { getCliDoctorStatus, findOpencodeCli } = await import('../cli-utils.js');
+    const status = getCliDoctorStatus();
+
+    expect(status.opencode).toEqual({
+      configuredCommand: 'opencode-custom',
+      resolvedPath: '/mock/bin/opencode-custom',
+      available: true,
+      lookup: 'env',
+    });
+    expect(findOpencodeCli()).toBe('opencode-custom');
   });
 });

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createTestClient, MCPTestClient } from './utils/mcp-client.js';
 import { getSharedMock, cleanupSharedMock } from './utils/persistent-mock.js';
+import { createOpenCodeMock } from './utils/opencode-mock.js';
 
 describe('Claude Code MCP E2E Tests', () => {
   let client: MCPTestClient;
@@ -40,40 +41,10 @@ describe('Claude Code MCP E2E Tests', () => {
       
       expect(tools).toHaveLength(6);
       const claudeCodeTool = tools.find((t: any) => t.name === 'run');
-      expect(claudeCodeTool).toEqual({
-        name: 'run',
-        description: expect.stringContaining('AI Agent Runner'),
-        inputSchema: {
-          type: 'object',
-          properties: {
-            prompt: {
-              type: 'string',
-              description: expect.stringContaining('Either this or prompt_file is required'),
-            },
-            prompt_file: {
-              type: 'string',
-              description: expect.stringContaining('Path to a file containing the prompt'),
-            },
-            workFolder: {
-              type: 'string',
-              description: expect.stringContaining('working directory'),
-            },
-            model: {
-              type: 'string',
-              description: expect.stringContaining('sonnet'),
-            },
-            reasoning_effort: {
-              type: 'string',
-              description: expect.stringContaining('model_reasoning_effort'),
-            },
-            session_id: {
-              type: 'string',
-              description: expect.stringContaining('session ID'),
-            },
-          },
-          required: ['workFolder'],
-        },
-      });
+      expect(claudeCodeTool.inputSchema.properties.model.description).toContain('sonnet');
+      expect(claudeCodeTool.inputSchema.properties.model.description).toContain('opencode');
+      expect(claudeCodeTool.inputSchema.properties.model.description).toContain('oc-<provider/model>');
+      expect(claudeCodeTool.inputSchema.properties.reasoning_effort.description).toContain('OpenCode');
       
       // Verify other tools exist
       expect(tools.some((t: any) => t.name === 'list_processes')).toBe(true);
@@ -216,6 +187,78 @@ describe('Claude Code MCP E2E Tests', () => {
         type: 'text',
         text: expect.stringContaining('pid'),
       }]);
+    });
+  });
+
+  describe('OpenCode flows', () => {
+    it('should execute and resume OpenCode runs through the MCP client', async () => {
+      await client.disconnect();
+
+      const opencodeArgsLogPath = join(testDir, 'opencode-args.log');
+      const { scriptPath } = createOpenCodeMock(testDir, {
+        argsLogPath: opencodeArgsLogPath,
+        defaultSessionId: 'ses-opencode-e2e',
+      });
+
+      client = createTestClient({
+        debug: false,
+        env: {
+          OPENCODE_CLI_NAME: scriptPath,
+        },
+      });
+      await client.connect();
+
+      const runResponse = await client.callTool('run', {
+        prompt: 'e2e OpenCode initial prompt',
+        workFolder: testDir,
+        model: 'opencode',
+      });
+      const runData = JSON.parse(runResponse[0].text);
+      expect(runData.agent).toBe('opencode');
+
+      const initialWait = JSON.parse((await client.callTool('wait', { pids: [runData.pid], timeout: 5 }))[0].text);
+      expect(initialWait).toHaveLength(1);
+      expect(initialWait[0]).toMatchObject({
+        pid: runData.pid,
+        agent: 'opencode',
+        status: 'completed',
+        exitCode: 0,
+        model: 'opencode',
+        session_id: 'ses-opencode-e2e',
+        agentOutput: {
+          message: 'Initial: e2e OpenCode initial prompt',
+          session_id: 'ses-opencode-e2e',
+        },
+      });
+
+      const resumedResponse = await client.callTool('run', {
+        prompt: 'e2e OpenCode resumed prompt',
+        workFolder: testDir,
+        model: 'oc-openai/gpt-5.4',
+        session_id: 'ses-opencode-e2e',
+      });
+      const resumedRunData = JSON.parse(resumedResponse[0].text);
+
+      const resumedWait = JSON.parse((await client.callTool('wait', { pids: [resumedRunData.pid], timeout: 5 }))[0].text);
+      expect(resumedWait).toHaveLength(1);
+      expect(resumedWait[0]).toMatchObject({
+        pid: resumedRunData.pid,
+        agent: 'opencode',
+        status: 'completed',
+        exitCode: 0,
+        model: 'oc-openai/gpt-5.4',
+        session_id: 'ses-opencode-e2e',
+        agentOutput: {
+          message: 'Resumed model openai/gpt-5.4: e2e OpenCode resumed prompt',
+          session_id: 'ses-opencode-e2e',
+        },
+      });
+
+      const invocationLog = readFileSync(opencodeArgsLogPath, 'utf-8').trim().split('\n');
+      expect(invocationLog[0]).toContain(`--dir ${testDir}`);
+      expect(invocationLog[0]).not.toContain('--model');
+      expect(invocationLog[1]).toContain('--session ses-opencode-e2e');
+      expect(invocationLog[1]).toContain('--model openai/gpt-5.4');
     });
   });
 

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -3,6 +3,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { cleanupSharedMock, getSharedMock } from './utils/persistent-mock.js';
+import { createOpenCodeMock } from './utils/opencode-mock.js';
 import { createTestClient, MCPTestClient } from './utils/mcp-client.js';
 
 function parseToolJson(content: any): any {
@@ -109,6 +110,13 @@ describe('MCP Contract Tests', () => {
       'session_id',
       'workFolder',
     ]);
+    expect(runTool.description).toContain('OpenCode');
+    expect(runTool.inputSchema.properties.model.description).toContain('opencode');
+    expect(runTool.inputSchema.properties.model.description).toContain('oc-<provider/model>');
+    expect(runTool.inputSchema.properties.reasoning_effort.description).toContain('OpenCode do not support reasoning_effort');
+    expect(runTool.inputSchema.properties.session_id.description).toBe(
+      'Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in-place via --session and may also be combined with explicit oc-<provider/model> selection.'
+    );
 
     const getResultTool = tools.find((tool: any) => tool.name === 'get_result');
     expect(getResultTool.inputSchema.required).toEqual(['pid']);
@@ -468,6 +476,177 @@ printf '%s\n' '{"type":"system","session_id":"session-verbose-1"}'
         reasoning_effort: 'high',
       })
     ).rejects.toThrow(/reasoning_effort is not supported for forge/i);
+  });
+
+  it('covers OpenCode end-to-end through the MCP process path', async () => {
+    await client.disconnect();
+
+    const opencodeArgsLogPath = join(testDir, 'opencode-args.log');
+    const { scriptPath: openCodeMockPath } = createOpenCodeMock(testDir, {
+      argsLogPath: opencodeArgsLogPath,
+      defaultSessionId: 'ses-opencode-contract',
+    });
+
+    client = createTestClient({
+      debug: false,
+      env: {
+        OPENCODE_CLI_NAME: openCodeMockPath,
+      },
+    });
+    await client.connect();
+
+    const initialRunResponse = await client.callTool('run', {
+      prompt: 'opencode-initial-prompt',
+      workFolder: testDir,
+      model: 'opencode',
+    });
+    const initialRunData = parseToolJson(initialRunResponse);
+
+    expect(initialRunData).toEqual({
+      pid: expect.any(Number),
+      status: 'started',
+      agent: 'opencode',
+      message: expect.any(String),
+    });
+
+    const initialWaitResponse = await client.callTool('wait', { pids: [initialRunData.pid], timeout: 5 });
+    const initialWaitData = parseToolJson(initialWaitResponse);
+
+    expect(initialWaitData).toHaveLength(1);
+    expect(initialWaitData[0]).toMatchObject({
+      pid: initialRunData.pid,
+      agent: 'opencode',
+      status: 'completed',
+      exitCode: 0,
+      model: 'opencode',
+      session_id: 'ses-opencode-contract',
+      agentOutput: {
+        message: 'Initial: opencode-initial-prompt',
+        session_id: 'ses-opencode-contract',
+        tokens: { total: 11833 },
+        cost: 0,
+      },
+    });
+
+    const resumedDefaultRunResponse = await client.callTool('run', {
+      prompt: 'opencode-resume-default',
+      workFolder: testDir,
+      model: 'opencode',
+      session_id: 'ses-opencode-contract',
+    });
+    const resumedDefaultRunData = parseToolJson(resumedDefaultRunResponse);
+
+    const resumedDefaultWaitResponse = await client.callTool('wait', { pids: [resumedDefaultRunData.pid], timeout: 5 });
+    const resumedDefaultWaitData = parseToolJson(resumedDefaultWaitResponse);
+
+    expect(resumedDefaultWaitData).toHaveLength(1);
+    expect(resumedDefaultWaitData[0]).toMatchObject({
+      pid: resumedDefaultRunData.pid,
+      agent: 'opencode',
+      status: 'completed',
+      exitCode: 0,
+      model: 'opencode',
+      session_id: 'ses-opencode-contract',
+      agentOutput: {
+        message: 'Resumed: opencode-resume-default',
+        session_id: 'ses-opencode-contract',
+        tokens: { total: 11833 },
+        cost: 0,
+      },
+    });
+
+    const resumedExplicitRunResponse = await client.callTool('run', {
+      prompt: 'opencode-resume-explicit',
+      workFolder: testDir,
+      model: 'oc-openai/gpt-5.4',
+      session_id: 'ses-opencode-contract',
+    });
+    const resumedExplicitRunData = parseToolJson(resumedExplicitRunResponse);
+
+    const resumedExplicitWaitResponse = await client.callTool('wait', { pids: [resumedExplicitRunData.pid], timeout: 5 });
+    const resumedExplicitWaitData = parseToolJson(resumedExplicitWaitResponse);
+
+    expect(resumedExplicitWaitData).toHaveLength(1);
+    expect(resumedExplicitWaitData[0]).toMatchObject({
+      pid: resumedExplicitRunData.pid,
+      agent: 'opencode',
+      status: 'completed',
+      exitCode: 0,
+      model: 'oc-openai/gpt-5.4',
+      session_id: 'ses-opencode-contract',
+      agentOutput: {
+        message: 'Resumed model openai/gpt-5.4: opencode-resume-explicit',
+        session_id: 'ses-opencode-contract',
+        tokens: { total: 11833 },
+        cost: 0,
+      },
+    });
+
+    const failedRunResponse = await client.callTool('run', {
+      prompt: 'please fail',
+      workFolder: testDir,
+      model: 'oc-openai/gpt-5.4',
+    });
+    const failedRunData = parseToolJson(failedRunResponse);
+
+    const compactFailedWait = parseToolJson(await client.callTool('wait', { pids: [failedRunData.pid], timeout: 5 }));
+    expect(compactFailedWait).toHaveLength(1);
+    expect(compactFailedWait[0]).toMatchObject({
+      pid: failedRunData.pid,
+      agent: 'opencode',
+      status: 'failed',
+      exitCode: 7,
+      model: 'oc-openai/gpt-5.4',
+      session_id: 'ses-opencode-contract',
+      stdout: expect.stringContaining('Partial failure output'),
+      stderr: expect.stringContaining('OpenCode failed for openai/gpt-5.4'),
+    });
+    expect(compactFailedWait[0]).not.toHaveProperty('agentOutput');
+
+    const verboseFailedResult = parseToolJson(await client.callTool('get_result', { pid: failedRunData.pid, verbose: true }));
+    expect(verboseFailedResult).toMatchObject({
+      pid: failedRunData.pid,
+      agent: 'opencode',
+      status: 'failed',
+      exitCode: 7,
+      model: 'oc-openai/gpt-5.4',
+      session_id: 'ses-opencode-contract',
+      stdout: expect.stringContaining('Partial failure output'),
+      stderr: expect.stringContaining('OpenCode failed for openai/gpt-5.4'),
+      agentOutput: {
+        message: 'Partial failure output',
+        session_id: 'ses-opencode-contract',
+        tokens: { total: 42 },
+        cost: 0,
+      },
+    });
+
+    const openCodeInvocations = readFileSync(opencodeArgsLogPath, 'utf-8').trim().split('\n');
+    expect(openCodeInvocations).toHaveLength(4);
+    expect(openCodeInvocations[0]).toContain('run --format json');
+    expect(openCodeInvocations[0]).toContain(`--dir ${testDir}`);
+    expect(openCodeInvocations[0]).not.toContain('--session');
+    expect(openCodeInvocations[0]).not.toContain('--model');
+
+    expect(openCodeInvocations[1]).toContain(`--dir ${testDir}`);
+    expect(openCodeInvocations[1]).toContain('--session ses-opencode-contract');
+    expect(openCodeInvocations[1]).not.toContain('--model');
+
+    expect(openCodeInvocations[2]).toContain(`--dir ${testDir}`);
+    expect(openCodeInvocations[2]).toContain('--session ses-opencode-contract');
+    expect(openCodeInvocations[2]).toContain('--model openai/gpt-5.4');
+
+    expect(openCodeInvocations[3]).toContain(`--dir ${testDir}`);
+    expect(openCodeInvocations[3]).toContain('--model openai/gpt-5.4');
+
+    await expect(
+      client.callTool('run', {
+        prompt: 'opencode-invalid-reasoning',
+        workFolder: testDir,
+        model: 'opencode',
+        reasoning_effort: 'high',
+      })
+    ).rejects.toThrow(/reasoning_effort is not supported for opencode/i);
   });
 
   it('keeps key invalid-input errors stable', async () => {

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCodexOutput, parseClaudeOutput, parseForgeOutput } from '../parsers.js';
+import { parseCodexOutput, parseClaudeOutput, parseForgeOutput, parseOpenCodeOutput } from '../parsers.js';
 
 describe('parseCodexOutput', () => {
   it('should parse basic Codex output with message and session_id', () => {
@@ -147,5 +147,77 @@ still streaming`;
 
   it('should return null for unrelated forge output', () => {
     expect(parseForgeOutput('plain text')).toBeNull();
+  });
+});
+
+describe('parseOpenCodeOutput', () => {
+  it('parses a single completed OpenCode step', () => {
+    const output = `{"type":"step_start","sessionID":"ses_1"}
+{"type":"text","sessionID":"ses_1","part":{"type":"text","text":"Hello"}}
+{"type":"step_finish","sessionID":"ses_1","part":{"type":"step-finish","tokens":{"total":11833},"cost":0}}`;
+
+    expect(parseOpenCodeOutput(output)).toEqual({
+      message: 'Hello',
+      session_id: 'ses_1',
+      tokens: { total: 11833 },
+      cost: 0,
+    });
+  });
+
+  it('returns the last completed step for multi-step output', () => {
+    const output = `{"type":"step_start","sessionID":"ses_2"}
+{"type":"text","sessionID":"ses_2","part":{"type":"text","text":"First"}}
+{"type":"step_finish","sessionID":"ses_2","part":{"type":"step-finish","tokens":{"total":10},"cost":0}}
+{"type":"step_start","sessionID":"ses_2"}
+{"type":"text","sessionID":"ses_2","part":{"type":"text","text":"Second"}}
+{"type":"step_finish","sessionID":"ses_2","part":{"type":"step-finish","tokens":{"total":20},"cost":1}}`;
+
+    expect(parseOpenCodeOutput(output)).toEqual({
+      message: 'Second',
+      session_id: 'ses_2',
+      tokens: { total: 20 },
+      cost: 1,
+    });
+  });
+
+  it('resets the current-step buffer on each step_start', () => {
+    const output = `{"type":"step_start","sessionID":"ses_3"}
+{"type":"text","sessionID":"ses_3","part":{"type":"text","text":"Discard me"}}
+{"type":"step_start","sessionID":"ses_3"}
+{"type":"text","sessionID":"ses_3","part":{"type":"text","text":"Keep me"}}
+{"type":"step_finish","sessionID":"ses_3","part":{"type":"step-finish","tokens":{"total":5},"cost":0}}`;
+
+    expect(parseOpenCodeOutput(output)).toEqual({
+      message: 'Keep me',
+      session_id: 'ses_3',
+      tokens: { total: 5 },
+      cost: 0,
+    });
+  });
+
+  it('returns partial output when text exists without step_finish', () => {
+    const output = `{"type":"step_start","sessionID":"ses_4"}
+{"type":"text","sessionID":"ses_4","part":{"type":"text","text":"Partial"}}`;
+
+    expect(parseOpenCodeOutput(output)).toEqual({
+      message: 'Partial',
+      session_id: 'ses_4',
+    });
+  });
+
+  it('ignores malformed lines and unknown event types', () => {
+    const output = `not-json
+{"type":"unknown","sessionID":"ses_5"}
+{"type":"text","sessionID":"ses_5","part":{"type":"text","text":"Hello"}}`;
+
+    expect(parseOpenCodeOutput(output)).toEqual({
+      message: 'Hello',
+      session_id: 'ses_5',
+    });
+  });
+
+  it('returns null when no useful OpenCode events exist', () => {
+    expect(parseOpenCodeOutput('{"type":"unknown"}')).toBeNull();
+    expect(parseOpenCodeOutput('')).toBeNull();
   });
 });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -201,6 +201,41 @@ describe('ClaudeCodeServer Unit Tests', () => {
     });
   });
 
+  describe('findOpencodeCli function', () => {
+    it('should fallback to PATH for OpenCode when no override is configured', async () => {
+      mockHomedir.mockReturnValue('/home/user');
+      mockExistsSync.mockImplementation((path) => path === '/usr/bin/opencode');
+      mockAccessSync.mockImplementation((filePath) => {
+        if (filePath === '/usr/bin/opencode') return undefined;
+        throw new Error('not executable');
+      });
+      process.env.PATH = '/usr/bin';
+
+      const module = await import('../server.js');
+      // @ts-ignore
+      const findOpencodeCli = module.default?.findOpencodeCli || module.findOpencodeCli;
+
+      expect(findOpencodeCli()).toBe('/usr/bin/opencode');
+    });
+
+    it('should use custom name from OPENCODE_CLI_NAME', async () => {
+      process.env.OPENCODE_CLI_NAME = 'opencode-custom';
+      mockHomedir.mockReturnValue('/home/user');
+      mockExistsSync.mockImplementation((path) => path === '/usr/bin/opencode-custom');
+      mockAccessSync.mockImplementation((filePath) => {
+        if (filePath === '/usr/bin/opencode-custom') return undefined;
+        throw new Error('not executable');
+      });
+      process.env.PATH = '/usr/bin';
+
+      const module = await import('../server.js');
+      // @ts-ignore
+      const findOpencodeCli = module.default?.findOpencodeCli || module.findOpencodeCli;
+
+      expect(findOpencodeCli()).toBe('opencode-custom');
+    });
+  });
+
   describe('spawnAsync function', () => {
     let mockProcess: any;
     
@@ -333,28 +368,28 @@ describe('ClaudeCodeServer Unit Tests', () => {
       );
     });
 
-    it('should set up tool handlers', async () => {
+    it('should include OpenCode in setup logging', async () => {
       mockHomedir.mockReturnValue('/home/user');
       mockExistsSync.mockReturnValue(true);
-      
-      const { Server } = await import('@modelcontextprotocol/sdk/server/index.js');
-      const mockSetRequestHandler = vi.fn();
+
       vi.mocked(Server).mockImplementation(function(this: any) {
-        this.setRequestHandler = mockSetRequestHandler;
+        this.setRequestHandler = vi.fn();
         this.connect = vi.fn();
         this.close = vi.fn();
         this.onerror = undefined;
         return this;
       });
-      
+
       const module = await import('../server.js');
       // @ts-ignore
       const { ClaudeCodeServer } = module;
-      
-      const server = new ClaudeCodeServer();
-      
-      expect(mockSetRequestHandler).toHaveBeenCalled();
+      new ClaudeCodeServer();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[Setup] Using OpenCode CLI command/path:')
+      );
     });
+
 
     it('should set up error handler', async () => {
       mockHomedir.mockReturnValue('/home/user');

--- a/src/__tests__/utils/opencode-mock.ts
+++ b/src/__tests__/utils/opencode-mock.ts
@@ -1,0 +1,108 @@
+import { chmodSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface OpenCodeMockOptions {
+  argsLogPath?: string;
+  defaultSessionId?: string;
+}
+
+export interface OpenCodeMockResult {
+  scriptPath: string;
+  argsLogPath?: string;
+}
+
+export function createOpenCodeMock(dir: string, options: OpenCodeMockOptions = {}): OpenCodeMockResult {
+  const scriptPath = join(dir, 'mock-opencode');
+  const defaultSessionId = options.defaultSessionId || 'ses-opencode-default';
+  const argsLogPath = options.argsLogPath;
+  const argsLogSection = argsLogPath
+    ? `printf '%s\n' "$*" >> "${argsLogPath}"\n`
+    : '';
+
+  writeFileSync(
+    scriptPath,
+    `#!/bin/bash
+set -euo pipefail
+
+prompt=""
+session_id=""
+session_provided=0
+model=""
+work_dir=""
+
+${argsLogSection}if [[ "\${1:-}" == "run" ]]; then
+  shift
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --format)
+      shift 2
+      ;;
+    --dir)
+      work_dir="$2"
+      shift 2
+      ;;
+    --session)
+      session_id="$2"
+      session_provided=1
+      shift 2
+      ;;
+    --model)
+      model="$2"
+      shift 2
+      ;;
+    *)
+      prompt="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$session_id" ]]; then
+  session_id="${defaultSessionId}"
+fi
+
+if [[ "$prompt" == *"sleep"* ]]; then
+  sleep 5
+fi
+
+if [[ "$prompt" == *"fail"* ]]; then
+  printf '{"type":"step_start","sessionID":"%s"}\n' "$session_id"
+  printf '{"type":"text","sessionID":"%s","part":{"type":"text","text":"Partial failure output"}}\n' "$session_id"
+  printf '{"type":"step_finish","sessionID":"%s","part":{"type":"step-finish","tokens":{"total":42},"cost":0}}\n' "$session_id"
+  printf 'OpenCode failed for %s in %s\n' "$model" "$work_dir" >&2
+  exit 7
+fi
+
+if [[ "$prompt" == *"multi-step"* ]]; then
+  printf '{"type":"step_start","sessionID":"%s"}\n' "$session_id"
+  printf '{"type":"text","sessionID":"%s","part":{"type":"text","text":"First step"}}\n' "$session_id"
+  printf '{"type":"step_finish","sessionID":"%s","part":{"type":"step-finish","tokens":{"total":11},"cost":0}}\n' "$session_id"
+  printf '{"type":"step_start","sessionID":"%s"}\n' "$session_id"
+  printf '{"type":"text","sessionID":"%s","part":{"type":"text","text":"Second step"}}\n' "$session_id"
+  printf '{"type":"step_finish","sessionID":"%s","part":{"type":"step-finish","tokens":{"total":22},"cost":1}}\n' "$session_id"
+  exit 0
+fi
+
+message_prefix="Initial"
+if [[ $session_provided -eq 1 ]]; then
+  message_prefix="Resumed"
+fi
+if [[ -n "$model" ]]; then
+  message_prefix="Model $model"
+  if [[ $session_provided -eq 1 ]]; then
+    message_prefix="Resumed model $model"
+  fi
+fi
+
+printf '{"type":"step_start","sessionID":"%s"}\n' "$session_id"
+printf '{"type":"text","sessionID":"%s","part":{"type":"text","text":"%s: %s"}}\n' "$session_id" "$message_prefix" "$prompt"
+printf '{"type":"step_finish","sessionID":"%s","part":{"type":"step-finish","tokens":{"total":11833},"cost":0}}\n' "$session_id"
+`,
+    'utf8',
+  );
+  chmodSync(scriptPath, 0o755);
+
+  return { scriptPath, argsLogPath };
+}

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -319,5 +319,49 @@ describe('Argument Validation Tests', () => {
         })
       ).rejects.toThrow(/reasoning_effort/i);
     });
+
+    it.each([
+      'oc-',
+      'oc-openai',
+      'oc-/gpt-5.4',
+      'oc-openai/',
+      ' oc-openai/gpt-5.4',
+      'oc-openai/gpt-5.4 ',
+    ])('should reject malformed OpenCode model syntax at runtime: %s', async (model) => {
+      await setupServer();
+      const handler = handlers.get('callTool')!;
+
+      await expect(
+        handler({
+          params: {
+            name: 'run',
+            arguments: {
+              prompt: 'test',
+              workFolder: '/tmp',
+              model,
+            }
+          }
+        })
+      ).rejects.toThrow('Invalid OpenCode model. Expected exact syntax oc-<provider/model>.');
+    });
+
+    it('should reject reasoning_effort for OpenCode runtime requests', async () => {
+      await setupServer();
+      const handler = handlers.get('callTool')!;
+
+      await expect(
+        handler({
+          params: {
+            name: 'run',
+            arguments: {
+              prompt: 'test',
+              workFolder: '/tmp',
+              model: 'opencode',
+              reasoning_effort: 'high',
+            }
+          }
+        })
+      ).rejects.toThrow('reasoning_effort is not supported for opencode.');
+    });
   });
 });

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -26,9 +26,9 @@ Options:
   --cwd <path>                 Working directory
   --prompt <text>              Prompt text
   --prompt-file <path>         Path to a prompt file
-  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.2-codex, codex-ultra, gemini-2.5-pro, gemini-ultra, forge)
-  --session-id <id>            Resume a previous session
-  --reasoning-effort <level>   Reasoning level for Claude/Codex only
+  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.2-codex, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
+  --session-id <id>            Resume a previous session, including OpenCode in-place resumes
+  --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Gemini, Forge, and OpenCode
   --help, -h                   Show this help message
 
 Compatibility aliases:
@@ -92,7 +92,7 @@ Options:
 
 export const DOCTOR_HELP_TEXT = `Usage: ai-cli doctor
 
-Check whether supported AI CLI binaries are available.
+Check whether supported AI CLI binaries are available, including OpenCode.
 
 Options:
   --help, -h                   Show this help message

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -8,7 +8,7 @@ import {
   type ServerResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { spawn } from 'node:child_process';
-import { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from '../cli-utils.js';
+import { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from '../cli-utils.js';
 import { getModelParameterDescription, getSupportedModelsDescription } from '../model-catalog.js';
 import { ProcessService } from '../process-service.js';
 
@@ -73,6 +73,7 @@ export class ClaudeCodeServer {
   private codexCliPath: string;
   private geminiCliPath: string;
   private forgeCliPath: string;
+  private opencodeCliPath: string;
   private processService: ProcessService;
   private sigintHandler?: () => Promise<void>;
   private packageVersion: string;
@@ -82,10 +83,12 @@ export class ClaudeCodeServer {
     this.codexCliPath = findCodexCli();
     this.geminiCliPath = findGeminiCli();
     this.forgeCliPath = findForgeCli();
+    this.opencodeCliPath = findOpencodeCli();
     console.error(`[Setup] Using Claude CLI command/path: ${this.claudeCliPath}`);
     console.error(`[Setup] Using Codex CLI command/path: ${this.codexCliPath}`);
     console.error(`[Setup] Using Gemini CLI command/path: ${this.geminiCliPath}`);
     console.error(`[Setup] Using Forge CLI command/path: ${this.forgeCliPath}`);
+    console.error(`[Setup] Using OpenCode CLI command/path: ${this.opencodeCliPath}`);
     this.packageVersion = SERVER_VERSION;
     this.processService = new ProcessService({
       cliPaths: {
@@ -93,6 +96,7 @@ export class ClaudeCodeServer {
         codex: this.codexCliPath,
         gemini: this.geminiCliPath,
         forge: this.forgeCliPath,
+        opencode: this.opencodeCliPath,
       },
     });
 
@@ -123,7 +127,7 @@ export class ClaudeCodeServer {
       tools: [
         {
           name: 'run',
-          description: `AI Agent Runner: Starts a Claude, Codex, Gemini, or Forge CLI process in the background and returns a PID immediately. Use list_processes and get_result to monitor progress.
+          description: `AI Agent Runner: Starts a Claude, Codex, Gemini, Forge, or OpenCode CLI process in the background and returns a PID immediately. Use list_processes and get_result to monitor progress.
 
 • File ops: Create, read, (fuzzy) edit, move, copy, delete, list files, analyze/ocr images, file content analysis
 • Code: Generate / analyse / refactor / fix
@@ -167,11 +171,11 @@ ${getSupportedModelsDescription()}
               },
               reasoning_effort: {
                 type: 'string',
-                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh". Forge does not support reasoning_effort in this integration.',
+                description: 'Reasoning control for Claude and Codex. Claude uses --effort with "low", "medium", "high". Codex uses model_reasoning_effort with "low", "medium", "high", "xhigh". Gemini, Forge, and OpenCode do not support reasoning_effort in this integration.',
               },
               session_id: {
                 type: 'string',
-                description: 'Optional session ID to resume a previous session. Supported for: haiku, sonnet, opus, gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview, forge.',
+                description: 'Optional session ID to resume a previous session. Supported for Claude, Codex, Gemini, Forge, and OpenCode. OpenCode resumes in-place via --session and may also be combined with explicit oc-<provider/model> selection.',
               },
             },
             required: ['workFolder'],

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -1,11 +1,21 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve as pathResolve, isAbsolute } from 'node:path';
+import type { CliPaths } from './cli-utils.js';
 import { MODEL_ALIASES } from './model-catalog.js';
 
 export const ALLOWED_REASONING_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh']);
 const CLAUDE_REASONING_EFFORTS = new Set(['low', 'medium', 'high']);
+const OPENCODE_MODEL_ERROR = 'Invalid OpenCode model. Expected exact syntax oc-<provider/model>.';
 
-function getAgentForModel(model: string): 'codex' | 'claude' | 'gemini' | 'forge' {
+type Agent = 'codex' | 'claude' | 'gemini' | 'forge' | 'opencode';
+
+interface ModelSelection {
+  agent: Agent;
+  resolvedModel: string;
+  openCodeModel: string | null;
+}
+
+function getStandardAgentForModel(model: string): Exclude<Agent, 'opencode'> {
   if (model === 'forge') {
     return 'forge';
   }
@@ -18,20 +28,63 @@ function getAgentForModel(model: string): 'codex' | 'claude' | 'gemini' | 'forge
   return 'claude';
 }
 
-/**
- * Resolves model aliases to their full model names
- * @param model - The model name or alias to resolve
- * @returns The full model name, or the original value if no alias exists
- */
+function isPotentialOpenCodeExplicitModel(rawModel: string): boolean {
+  return rawModel.startsWith('oc-') || rawModel.trim().startsWith('oc-');
+}
+
+function extractOpenCodeModel(rawModel: string): string {
+  if (rawModel !== rawModel.trim()) {
+    throw new Error(OPENCODE_MODEL_ERROR);
+  }
+
+  if (!rawModel.startsWith('oc-')) {
+    throw new Error(OPENCODE_MODEL_ERROR);
+  }
+
+  const remainder = rawModel.slice(3);
+  const slashIndex = remainder.indexOf('/');
+  if (slashIndex === -1) {
+    throw new Error(OPENCODE_MODEL_ERROR);
+  }
+
+  const provider = remainder.slice(0, slashIndex);
+  const model = remainder.slice(slashIndex + 1);
+  if (!provider || !model) {
+    throw new Error(OPENCODE_MODEL_ERROR);
+  }
+
+  return remainder;
+}
+
+function resolveModelSelection(rawModel: string): ModelSelection {
+  if (rawModel === 'opencode') {
+    return {
+      agent: 'opencode',
+      resolvedModel: rawModel,
+      openCodeModel: null,
+    };
+  }
+
+  if (isPotentialOpenCodeExplicitModel(rawModel)) {
+    return {
+      agent: 'opencode',
+      resolvedModel: rawModel,
+      openCodeModel: extractOpenCodeModel(rawModel),
+    };
+  }
+
+  const resolvedModel = resolveModelAlias(rawModel);
+  return {
+    agent: getStandardAgentForModel(resolvedModel),
+    resolvedModel,
+    openCodeModel: null,
+  };
+}
+
 export function resolveModelAlias(model: string): string {
   return MODEL_ALIASES[model] || model;
 }
 
-/**
- * Validates and normalizes reasoning effort parameter.
- * @returns normalized reasoning effort string, or '' if not applicable
- * @throws Error for invalid values (plain Error, not MCP-specific)
- */
 export function getReasoningEffort(model: string, rawValue: unknown): string {
   if (typeof rawValue !== 'string') {
     return '';
@@ -40,13 +93,18 @@ export function getReasoningEffort(model: string, rawValue: unknown): string {
   if (!trimmed) {
     return '';
   }
+
+  if (model === 'opencode' || model.startsWith('oc-')) {
+    throw new Error('reasoning_effort is not supported for opencode.');
+  }
+
   const normalized = trimmed.toLowerCase();
   if (!ALLOWED_REASONING_EFFORTS.has(normalized)) {
     throw new Error(
       `Invalid reasoning_effort: ${rawValue}. Allowed values: low, medium, high, xhigh.`
     );
   }
-  const agent = getAgentForModel(model);
+  const agent = getStandardAgentForModel(model);
   if (agent === 'forge') {
     throw new Error('reasoning_effort is not supported for forge.');
   }
@@ -67,7 +125,7 @@ export interface CliCommand {
   cliPath: string;
   args: string[];
   cwd: string;
-  agent: 'claude' | 'codex' | 'gemini' | 'forge';
+  agent: Agent;
   prompt: string;
   resolvedModel: string;
 }
@@ -79,21 +137,14 @@ export interface BuildCliCommandOptions {
   model?: string;
   session_id?: string;
   reasoning_effort?: string;
-  cliPaths: { claude: string; codex: string; gemini: string; forge: string };
+  cliPaths: CliPaths;
 }
 
-/**
- * Build a CLI command from the given options.
- * This is a pure function (aside from filesystem reads for prompt_file / workFolder validation).
- * @throws Error on validation failures
- */
 export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
-  // Validate workFolder
   if (!options.workFolder || typeof options.workFolder !== 'string') {
     throw new Error('Missing or invalid required parameter: workFolder');
   }
 
-  // Validate prompt / prompt_file
   const hasPrompt = !!options.prompt && typeof options.prompt === 'string' && options.prompt.trim() !== '';
   const hasPromptFile = !!options.prompt_file && typeof options.prompt_file === 'string' && options.prompt_file.trim() !== '';
 
@@ -105,7 +156,6 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     throw new Error('Cannot specify both prompt and prompt_file. Please use only one.');
   }
 
-  // Determine prompt
   let prompt: string;
   if (hasPrompt) {
     prompt = options.prompt!;
@@ -125,18 +175,14 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
   }
 
-  // Resolve workFolder
   const cwd = pathResolve(options.workFolder);
   if (!existsSync(cwd)) {
     throw new Error(`Working folder does not exist: ${options.workFolder}`);
   }
 
-  // Resolve model
   const rawModel = options.model || '';
-  const resolvedModel = resolveModelAlias(rawModel);
-  const agent = getAgentForModel(resolvedModel);
+  const { agent, resolvedModel, openCodeModel } = resolveModelSelection(rawModel);
 
-  // Special handling for ultra aliases: default to higher reasoning if not specified
   let reasoningEffortArg: string | undefined = options.reasoning_effort;
   if (!reasoningEffortArg) {
     if (rawModel === 'codex-ultra') {
@@ -146,9 +192,11 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
   }
 
-  const reasoningEffort = getReasoningEffort(resolvedModel, reasoningEffortArg);
+  const reasoningTargetModel = rawModel === 'opencode' || rawModel.startsWith('oc-')
+    ? rawModel
+    : (resolvedModel || rawModel);
+  const reasoningEffort = getReasoningEffort(reasoningTargetModel, reasoningEffortArg);
 
-  // Build CLI path and args
   let cliPath: string;
   let args: string[];
 
@@ -169,7 +217,6 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
 
     args.push('--skip-git-repo-check', '--full-auto', '--json', prompt);
-
   } else if (agent === 'gemini') {
     cliPath = options.cliPaths.gemini;
     args = ['-y', '--output-format', 'json'];
@@ -183,7 +230,6 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
 
     args.push(prompt);
-
   } else if (agent === 'forge') {
     cliPath = options.cliPaths.forge;
     args = ['-C', cwd];
@@ -193,6 +239,19 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     }
 
     args.push('-p', prompt);
+  } else if (agent === 'opencode') {
+    cliPath = options.cliPaths.opencode;
+    args = ['run', '--format', 'json', '--dir', cwd];
+
+    if (options.session_id && typeof options.session_id === 'string') {
+      args.push('--session', options.session_id);
+    }
+
+    if (openCodeModel) {
+      args.push('--model', openCodeModel);
+    }
+
+    args.push(prompt);
   } else {
     cliPath = options.cliPaths.claude;
     args = ['--dangerously-skip-permissions', '--output-format', 'stream-json', '--verbose'];

--- a/src/cli-parse.ts
+++ b/src/cli-parse.ts
@@ -1,20 +1,23 @@
 #!/usr/bin/env node
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput } from './parsers.js';
 
-const AGENTS = ['claude', 'codex', 'gemini', 'forge'] as const;
+const AGENTS = ['claude', 'codex', 'gemini', 'forge', 'opencode'] as const;
 type Agent = typeof AGENTS[number];
 
-const USAGE = `Usage: npm run -s cli.run.parse -- --agent <claude|codex|gemini|forge>
+const USAGE = `Usage: npm run -s cli.run.parse -- --agent <claude|codex|gemini|forge|opencode>
 
 Reads raw CLI output from stdin and outputs parsed JSON to stdout.
 
 Options:
-  --agent   Agent type: claude, codex, gemini, or forge (required)
+  --agent   Agent type: claude, codex, gemini, forge, or opencode (required)
   --help    Show this help message
 
 Examples:
   npm run -s cli.run -- --model sonnet --workFolder /tmp --prompt "hi" > raw.txt
   npm run -s cli.run.parse -- --agent claude < raw.txt
+
+  npm run -s cli.run -- --model opencode --workFolder /tmp --prompt "hi" > raw.txt
+  npm run -s cli.run.parse -- --agent opencode < raw.txt
 
   # Or pipe directly
   npm run -s cli.run -- --model sonnet --workFolder /tmp --prompt "hi" | npm run -s cli.run.parse -- --agent claude
@@ -62,7 +65,7 @@ async function main(): Promise<void> {
 
   const agent = args.agent as Agent;
   if (!agent || !AGENTS.includes(agent)) {
-    process.stderr.write(`Error: --agent is required (claude, codex, gemini, or forge)\n\n`);
+    process.stderr.write(`Error: --agent is required (claude, codex, gemini, forge, or opencode)\n\n`);
     process.stderr.write(USAGE);
     process.exit(1);
   }
@@ -87,6 +90,9 @@ async function main(): Promise<void> {
       break;
     case 'forge':
       parsed = parseForgeOutput(input);
+      break;
+    case 'opencode':
+      parsed = parseOpenCodeOutput(input);
       break;
   }
 

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import {
+  chmodSync,
   closeSync,
   existsSync,
   mkdirSync,
@@ -15,8 +16,8 @@ import {
 import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
+import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput } from './parsers.js';
 import { buildProcessResult } from './process-result.js';
 import type { AgentType, ProcessListItem } from './process-service.js';
 
@@ -31,6 +32,12 @@ interface StoredProcess {
   stdoutPath: string;
   stderrPath: string;
   status: 'running' | 'completed' | 'failed';
+  exitCode?: number;
+}
+
+interface StoredExitStatus {
+  status: 'completed' | 'failed';
+  exitCode?: number;
 }
 
 interface CliProcessServiceOptions {
@@ -70,6 +77,30 @@ function normalizeCwdForStorage(cwd: string): string {
     .join('');
 }
 
+function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any {
+  if (agent === 'codex') {
+    return parseCodexOutput(`${stdout}\n${stderr}`);
+  }
+
+  if (!stdout) {
+    return null;
+  }
+
+  if (agent === 'claude') {
+    return parseClaudeOutput(stdout);
+  }
+  if (agent === 'gemini') {
+    return parseGeminiOutput(stdout);
+  }
+  if (agent === 'forge') {
+    return parseForgeOutput(stdout);
+  }
+  if (agent === 'opencode') {
+    return parseOpenCodeOutput(stdout);
+  }
+  return null;
+}
+
 export class CliProcessService {
   private readonly stateDir: string;
   private readonly cliPaths: BuildCliCommandOptions['cliPaths'];
@@ -81,6 +112,7 @@ export class CliProcessService {
       codex: findCodexCli(),
       gemini: findGeminiCli(),
       forge: findForgeCli(),
+      opencode: findOpencodeCli(),
     };
     mkdirSync(this.stateDir, { recursive: true });
   }
@@ -95,6 +127,10 @@ export class CliProcessService {
       reasoning_effort: options.reasoning_effort,
       cliPaths: this.cliPaths,
     });
+
+    if (cmd.agent === 'opencode') {
+      return this.startDetachedOpenCodeProcess(cmd, options.model);
+    }
 
     const stdoutPath = this.resolveStdoutPathForPidPlaceholder();
     const stderrPath = this.resolveStderrPathForPidPlaceholder();
@@ -172,25 +208,13 @@ export class CliProcessService {
     const refreshed = this.refreshStatus(storedProcess);
     const stdout = this.readTextFileSafe(refreshed.stdoutPath);
     const stderr = this.readTextFileSafe(refreshed.stderrPath);
-
-    let agentOutput: any = null;
-    if (refreshed.toolType === 'codex') {
-      agentOutput = parseCodexOutput(`${stdout}\n${stderr}`);
-    } else if (stdout) {
-      if (refreshed.toolType === 'claude') {
-        agentOutput = parseClaudeOutput(stdout);
-      } else if (refreshed.toolType === 'gemini') {
-        agentOutput = parseGeminiOutput(stdout);
-      } else if (refreshed.toolType === 'forge') {
-        agentOutput = parseForgeOutput(stdout);
-      }
-    }
+    const agentOutput = parseAgentOutput(refreshed.toolType, stdout, stderr);
 
     return buildProcessResult({
       pid,
       agent: refreshed.toolType,
       status: refreshed.status,
-      exitCode: undefined,
+      exitCode: refreshed.exitCode,
       startTime: refreshed.startTime,
       workFolder: refreshed.workFolder,
       prompt: refreshed.prompt,
@@ -277,6 +301,59 @@ export class CliProcessService {
     };
   }
 
+  private async startDetachedOpenCodeProcess(
+    cmd: Awaited<ReturnType<typeof buildCliCommand>>,
+    model: string | undefined,
+  ): Promise<{ pid: number; status: 'started'; agent: AgentType; message: string }> {
+    const cwdKey = this.resolveCwdKey(cmd.cwd);
+    const wrapperPath = this.ensureOpenCodeWrapperScript();
+
+    const childProcess = spawn(wrapperPath, [this.stateDir, cwdKey, cmd.cliPath, ...cmd.args], {
+      cwd: cmd.cwd,
+      detached: true,
+      stdio: 'ignore',
+    });
+
+    const pid = childProcess.pid;
+    childProcess.unref();
+
+    if (!pid) {
+      throw new Error(`Failed to start ${cmd.agent} CLI process`);
+    }
+
+    const processDir = this.resolveProcessDir(cmd.cwd, pid);
+    mkdirSync(processDir, { recursive: true });
+    const stdoutPath = this.resolveStdoutPath(processDir);
+    const stderrPath = this.resolveStderrPath(processDir);
+    if (!existsSync(stdoutPath)) {
+      writeFileSync(stdoutPath, '');
+    }
+    if (!existsSync(stderrPath)) {
+      writeFileSync(stderrPath, '');
+    }
+
+    const storedProcess: StoredProcess = {
+      pid,
+      prompt: cmd.prompt,
+      workFolder: cmd.cwd,
+      cwdKey,
+      model,
+      toolType: cmd.agent,
+      startTime: new Date().toISOString(),
+      stdoutPath,
+      stderrPath,
+      status: 'running',
+    };
+    this.writeProcess(storedProcess);
+
+    return {
+      pid,
+      status: 'started',
+      agent: cmd.agent,
+      message: `${cmd.agent} process started successfully`,
+    };
+  }
+
   private readAllProcesses(): StoredProcess[] {
     const cwdsDir = this.resolveCwdsDir();
     if (!existsSync(cwdsDir)) {
@@ -320,11 +397,45 @@ export class CliProcessService {
   }
 
   private refreshStatus(process: StoredProcess): StoredProcess {
-    if (process.status === 'running' && !isProcessRunning(process.pid)) {
+    if (process.status !== 'running') {
+      return process;
+    }
+
+    const persistedExitStatus = this.readExitStatus(process);
+    if (persistedExitStatus) {
+      process.status = persistedExitStatus.status;
+      process.exitCode = persistedExitStatus.exitCode;
+      this.writeProcess(process);
+      return process;
+    }
+
+    if (!isProcessRunning(process.pid)) {
       process.status = 'completed';
       this.writeProcess(process);
     }
     return process;
+  }
+
+  private readExitStatus(process: StoredProcess): StoredExitStatus | null {
+    if (process.toolType !== 'opencode') {
+      return null;
+    }
+
+    const exitMetaPath = this.resolveExitStatusPath(this.resolveStoredProcessDir(process));
+    if (!existsSync(exitMetaPath)) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(readFileSync(exitMetaPath, 'utf-8')) as StoredExitStatus;
+      if (parsed.status === 'completed' || parsed.status === 'failed') {
+        return parsed;
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
   }
 
   private readTextFileSafe(filePath: string): string {
@@ -365,12 +476,55 @@ export class CliProcessService {
     return join(processDir, 'stderr.log');
   }
 
+  private resolveExitStatusPath(processDir: string): string {
+    return join(processDir, 'exit-status.json');
+  }
+
+  private resolveOpenCodeWrapperPath(): string {
+    return join(this.stateDir, 'opencode-detached-wrapper.sh');
+  }
+
   private resolveStdoutPathForPidPlaceholder(): string {
     return join(this.stateDir, `pending-${Date.now()}-${Math.random().toString(36).slice(2)}.stdout.log`);
   }
 
   private resolveStderrPathForPidPlaceholder(): string {
     return join(this.stateDir, `pending-${Date.now()}-${Math.random().toString(36).slice(2)}.stderr.log`);
+  }
+
+  private ensureOpenCodeWrapperScript(): string {
+    const wrapperPath = this.resolveOpenCodeWrapperPath();
+    if (existsSync(wrapperPath)) {
+      return wrapperPath;
+    }
+
+    writeFileSync(
+      wrapperPath,
+      `#!/bin/sh
+set +e
+state_dir="$1"
+cwd_key="$2"
+shift 2
+pid="$$"
+process_dir="$state_dir/cwds/$cwd_key/$pid"
+stdout_path="$process_dir/stdout.log"
+stderr_path="$process_dir/stderr.log"
+exit_meta_path="$process_dir/exit-status.json"
+mkdir -p "$process_dir"
+: > "$stdout_path"
+: > "$stderr_path"
+"$@" >> "$stdout_path" 2>> "$stderr_path"
+exit_code="$?"
+status="completed"
+if [ "$exit_code" -ne 0 ]; then
+  status="failed"
+fi
+printf '{\n  "status": "%s",\n  "exitCode": %s\n}\n' "$status" "$exit_code" > "$exit_meta_path"
+exit "$exit_code"
+`,
+    );
+    chmodSync(wrapperPath, 0o755);
+    return wrapperPath;
   }
 
   private renamePlaceholderFile(fromPath: string, toPath: string): void {

--- a/src/cli-utils.ts
+++ b/src/cli-utils.ts
@@ -3,10 +3,8 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as path from 'path';
 
-// Define debugMode globally using const
 const debugMode = process.env.MCP_CLAUDE_DEBUG === 'true';
 
-// Dedicated debug logging function
 export function debugLog(message?: any, ...optionalParams: any[]): void {
   if (debugMode) {
     console.error(message, ...optionalParams);
@@ -19,6 +17,24 @@ export interface CliBinaryStatus {
   available: boolean;
   lookup: 'env' | 'local' | 'path';
   error?: string;
+}
+
+export type CliBinaryName = 'claude' | 'codex' | 'gemini' | 'forge' | 'opencode';
+
+export interface CliPaths {
+  claude: string;
+  codex: string;
+  gemini: string;
+  forge: string;
+  opencode: string;
+}
+
+export interface CliDoctorStatus {
+  claude: CliBinaryStatus;
+  codex: CliBinaryStatus;
+  gemini: CliBinaryStatus;
+  forge: CliBinaryStatus;
+  opencode: CliBinaryStatus;
 }
 
 function getPathDelimiter(): string {
@@ -75,7 +91,7 @@ function inspectCliBinary(options: {
   envVarName: string;
   customCliName: string | undefined;
   defaultCliName: string;
-  localInstallPath: string;
+  localInstallPath?: string;
 }): CliBinaryStatus {
   const configuredCommand = options.customCliName || options.defaultCliName;
 
@@ -109,7 +125,7 @@ function inspectCliBinary(options: {
     };
   }
 
-  if (isExecutableFile(options.localInstallPath)) {
+  if (options.localInstallPath && isExecutableFile(options.localInstallPath)) {
     return {
       configuredCommand,
       resolvedPath: options.localInstallPath,
@@ -148,13 +164,11 @@ function isExecutableFile(filePath: string): boolean {
   }
 }
 
-type CliBinaryName = 'claude' | 'codex' | 'gemini' | 'forge';
-
 function getCliBinaryConfig(name: CliBinaryName): {
   envVarName: string;
   customCliName: string | undefined;
   defaultCliName: string;
-  localInstallPath: string;
+  localInstallPath?: string;
 } {
   if (name === 'claude') {
     return {
@@ -183,6 +197,14 @@ function getCliBinaryConfig(name: CliBinaryName): {
     };
   }
 
+  if (name === 'opencode') {
+    return {
+      envVarName: 'OPENCODE_CLI_NAME',
+      customCliName: process.env.OPENCODE_CLI_NAME,
+      defaultCliName: 'opencode',
+    };
+  }
+
   return {
     envVarName: 'GEMINI_CLI_NAME',
     customCliName: process.env.GEMINI_CLI_NAME,
@@ -195,58 +217,40 @@ function getCliBinaryStatus(name: CliBinaryName): CliBinaryStatus {
   return inspectCliBinary(getCliBinaryConfig(name));
 }
 
-export function getCliDoctorStatus(): {
-  claude: CliBinaryStatus;
-  codex: CliBinaryStatus;
-  gemini: CliBinaryStatus;
-  forge: CliBinaryStatus;
-} {
+export function getCliDoctorStatus(): CliDoctorStatus {
   return {
     claude: getCliBinaryStatus('claude'),
     codex: getCliBinaryStatus('codex'),
     gemini: getCliBinaryStatus('gemini'),
     forge: getCliBinaryStatus('forge'),
+    opencode: getCliBinaryStatus('opencode'),
   };
 }
 
-/**
- * Determine the Gemini CLI command/path.
- * Similar to findClaudeCli but for Gemini
- */
 export function findGeminiCli(): string {
   debugLog('[Debug] Attempting to find Gemini CLI...');
   const status = getCliBinaryStatus('gemini');
   return getCliCommandOrThrow(status);
 }
 
-/**
- * Determine the Codex CLI command/path.
- * Similar to findClaudeCli but for Codex
- */
 export function findCodexCli(): string {
   debugLog('[Debug] Attempting to find Codex CLI...');
   const status = getCliBinaryStatus('codex');
   return getCliCommandOrThrow(status);
 }
 
-/**
- * Determine the Forge CLI command/path.
- */
 export function findForgeCli(): string {
   debugLog('[Debug] Attempting to find Forge CLI...');
   const status = getCliBinaryStatus('forge');
   return getCliCommandOrThrow(status);
 }
 
-/**
- * Determine the Claude CLI command/path.
- * 1. Checks for CLAUDE_CLI_NAME environment variable:
- *    - If absolute path, uses it directly
- *    - If relative path, throws error
- *    - If simple name, continues with path resolution
- * 2. Checks for Claude CLI at the local user path: ~/.claude/local/claude.
- * 3. If not found, defaults to the CLI name (or 'claude'), relying on the system's PATH for lookup.
- */
+export function findOpencodeCli(): string {
+  debugLog('[Debug] Attempting to find OpenCode CLI...');
+  const status = getCliBinaryStatus('opencode');
+  return getCliCommandOrThrow(status);
+}
+
 export function findClaudeCli(): string {
   debugLog('[Debug] Attempting to find Claude CLI...');
   const status = getCliBinaryStatus('claude');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { buildCliCommand } from './cli-builder.js';
-import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
+import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
 
 /**
  * Minimal argv parser. No external dependencies.
@@ -35,17 +35,18 @@ function parseArgs(argv: string[]): Record<string, string> {
 const USAGE = `Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]
 
 Options:
-  --model              Model name or alias (e.g. sonnet, opus, gpt-5.2-codex, gemini-2.5-pro, forge)
+  --model              Model name or alias (e.g. sonnet, opus, gpt-5.2-codex, gemini-2.5-pro, forge, opencode, oc-openai/gpt-5.4)
   --workFolder         Working directory (absolute path)
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt
-  --session_id         Session ID to resume
-  --reasoning_effort   Claude/Codex only: Claude=low|medium|high, Codex=low|medium|high|xhigh
+  --session_id         Session ID to resume, including OpenCode in-place resumes
+  --reasoning_effort   Claude/Codex only: Claude=low|medium|high, Codex=low|medium|high|xhigh; unsupported for Gemini, Forge, and OpenCode
   --help               Show this help message
 
 Raw CLI output goes to stdout. Use cli.run.parse to parse the output:
   npm run -s cli.run -- ... > raw.txt
   npm run -s cli.run.parse -- --agent claude < raw.txt
+  npm run -s cli.run.parse -- --agent opencode < raw.txt
 `;
 
 async function main(): Promise<void> {
@@ -74,6 +75,7 @@ async function main(): Promise<void> {
     codex: findCodexCli(),
     gemini: findGeminiCli(),
     forge: findForgeCli(),
+    opencode: findOpencodeCli(),
   };
 
   // Build command

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -20,6 +20,7 @@ export const GEMINI_MODELS = [
   'gemini-3-flash-preview',
 ] as const;
 export const FORGE_MODELS = ['forge'] as const;
+export const OPENCODE_MODELS = ['opencode'] as const;
 
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
@@ -33,6 +34,13 @@ export const MODEL_ALIAS_DETAILS = [
   { name: 'gemini-ultra', resolvesTo: 'gemini-3.1-pro-preview', agent: 'gemini' },
 ] as const;
 
+export interface DynamicModelBackendDescription {
+  explicitPrefix: string;
+  explicitPattern: string;
+  discoveryCommand: string;
+  modelsAreDynamic: boolean;
+}
+
 export function getSupportedModelsDescription(): string {
   return [
     '"claude-ultra", "codex-ultra", "gemini-ultra"',
@@ -40,11 +48,13 @@ export function getSupportedModelsDescription(): string {
     ...CODEX_MODELS.map((model) => `"${model}"`),
     ...GEMINI_MODELS.map((model) => `"${model}"`),
     ...FORGE_MODELS.map((model) => `"${model}"`),
+    ...OPENCODE_MODELS.map((model) => `"${model}"`),
+    '"oc-<provider/model>"',
   ].join(', ');
 }
 
 export function getModelParameterDescription(): string {
-  return `The model to use. Aliases: "claude-ultra" (auto high effort), "codex-ultra" (auto xhigh reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS, ...FORGE_MODELS].map((model) => `"${model}"`).join(', ')}. "forge" is a provider key, not a Forge model family selector.`;
+  return `The model to use. Aliases: "claude-ultra" (auto high effort), "codex-ultra" (auto xhigh reasoning), "gemini-ultra". Standard: ${[...CLAUDE_MODELS, ...CODEX_MODELS, ...GEMINI_MODELS, ...FORGE_MODELS, ...OPENCODE_MODELS].map((model) => `"${model}"`).join(', ')}. OpenCode also accepts explicit dynamic models using "oc-<provider/model>". "forge" is a provider key, not a Forge model family selector.`;
 }
 
 export function getModelsPayload(): {
@@ -53,6 +63,10 @@ export function getModelsPayload(): {
   codex: ReadonlyArray<string>;
   gemini: ReadonlyArray<string>;
   forge: ReadonlyArray<string>;
+  opencode: ReadonlyArray<string>;
+  dynamicModelBackends: {
+    opencode: DynamicModelBackendDescription;
+  };
 } {
   return {
     aliases: MODEL_ALIAS_DETAILS,
@@ -60,5 +74,14 @@ export function getModelsPayload(): {
     codex: CODEX_MODELS,
     gemini: GEMINI_MODELS,
     forge: FORGE_MODELS,
+    opencode: OPENCODE_MODELS,
+    dynamicModelBackends: {
+      opencode: {
+        explicitPrefix: 'oc-',
+        explicitPattern: 'oc-<provider/model>',
+        discoveryCommand: 'opencode models',
+        modelsAreDynamic: true,
+      },
+    },
   };
 }

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,18 +1,15 @@
 import { debugLog } from './cli-utils.js';
 
-/**
- * Parse Codex NDJSON output to extract the last agent message and token count
- */
 export function parseCodexOutput(stdout: string): any {
   if (!stdout) return null;
-  
+
   try {
     const lines = stdout.trim().split('\n');
     let lastMessage = null;
     let tokenCount = null;
     let threadId = null;
     const tools: any[] = [];
-    
+
     for (const line of lines) {
       if (line.trim()) {
         try {
@@ -24,14 +21,13 @@ export function parseCodexOutput(stdout: string): any {
           } else if (parsed.msg?.type === 'agent_message') {
             lastMessage = parsed.msg.message;
           } else if (parsed.item?.type === 'reasoning') {
-            // Ignore reasoning-only items for message selection.
           } else if (parsed.msg?.type === 'token_count') {
             tokenCount = parsed.msg;
           } else if (parsed.type === 'item.completed' && parsed.item?.type === 'mcp_tool_call') {
             tools.push({
               server: parsed.item.server,
               tool: parsed.item.tool,
-              input: parsed.item.arguments, // Map arguments to input to match common patterns
+              input: parsed.item.arguments,
               output: parsed.item.result
             });
           } else if (parsed.type === 'item.completed' && parsed.item?.type === 'command_execution') {
@@ -43,12 +39,11 @@ export function parseCodexOutput(stdout: string): any {
             });
           }
         } catch (e) {
-          // Skip invalid JSON lines
           debugLog(`[Debug] Skipping invalid JSON line: ${line}`);
         }
       }
     }
-    
+
     if (lastMessage || tokenCount || threadId || tools.length > 0) {
       return {
         message: lastMessage,
@@ -60,28 +55,23 @@ export function parseCodexOutput(stdout: string): any {
   } catch (e) {
     debugLog(`[Debug] Failed to parse Codex NDJSON output: ${e}`);
   }
-  
+
   return null;
 }
 
-/**
- * Parse Claude Output (supports both JSON and stream-json/NDJSON)
- */
 export function parseClaudeOutput(stdout: string): any {
   if (!stdout) return null;
 
-  // First try parsing as a single JSON object (backward compatibility)
   try {
     return JSON.parse(stdout);
   } catch (e) {
-    // If not valid single JSON, proceed to parse as NDJSON
   }
 
   try {
     const lines = stdout.trim().split('\n');
     let lastMessage = null;
     let sessionId = null;
-    const toolsMap = new Map<string, any>(); // Map by tool_use id for matching results
+    const toolsMap = new Map<string, any>();
 
     for (const line of lines) {
       if (!line.trim()) continue;
@@ -89,36 +79,31 @@ export function parseClaudeOutput(stdout: string): any {
       try {
         const parsed = JSON.parse(line);
 
-        // Extract session ID from any message that has it
         if (parsed.session_id) {
           sessionId = parsed.session_id;
         }
 
-        // Extract final result message
         if (parsed.type === 'result' && parsed.result) {
           lastMessage = parsed.result;
         }
 
-        // Extract tool usage from assistant messages
         if (parsed.type === 'assistant' && parsed.message?.content) {
           for (const content of parsed.message.content) {
             if (content.type === 'tool_use') {
               toolsMap.set(content.id, {
                 tool: content.name,
                 input: content.input,
-                output: null // Will be filled when tool_result is found
+                output: null
               });
             }
           }
         }
 
-        // Match tool results from user messages
         if (parsed.type === 'user' && parsed.message?.content) {
           for (const content of parsed.message.content) {
             if (content.type === 'tool_result' && content.tool_use_id) {
               const tool = toolsMap.get(content.tool_use_id);
               if (tool) {
-                // Extract text from content array
                 if (Array.isArray(content.content)) {
                   const textContent = content.content.find((c: any) => c.type === 'text');
                   tool.output = textContent?.text || null;
@@ -135,12 +120,11 @@ export function parseClaudeOutput(stdout: string): any {
       }
     }
 
-    // Convert Map to array
     const tools = Array.from(toolsMap.values());
 
     if (lastMessage || sessionId || tools.length > 0) {
       return {
-        message: lastMessage, // This is the final result text
+        message: lastMessage,
         session_id: sessionId,
         tools: tools.length > 0 ? tools : undefined
       };
@@ -150,13 +134,10 @@ export function parseClaudeOutput(stdout: string): any {
     debugLog(`[Debug] Failed to parse Claude NDJSON output: ${e}`);
     return null;
   }
-  
+
   return null;
 }
 
-/**
- * Parse Gemini JSON output
- */
 export function parseGeminiOutput(stdout: string): any {
   if (!stdout) return null;
 
@@ -168,9 +149,6 @@ export function parseGeminiOutput(stdout: string): any {
   }
 }
 
-/**
- * Parse Forge output framed by Initialize/Continue/Finished markers.
- */
 export function parseForgeOutput(stdout: string): any {
   if (!stdout) return null;
 
@@ -227,4 +205,72 @@ export function parseForgeOutput(stdout: string): any {
     message: lastMessage,
     session_id: lastConversationId,
   };
+}
+
+export function parseOpenCodeOutput(stdout: string): any {
+  if (!stdout) {
+    return null;
+  }
+
+  let sessionId: string | null = null;
+  let currentStepBuffer = '';
+  let latestCompletedStep: {
+    message: string;
+    session_id?: string;
+    tokens?: any;
+    cost?: number;
+  } | null = null;
+  let hasStepFinish = false;
+  let hasParseableAssistantText = false;
+
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (typeof parsed.sessionID === 'string' && parsed.sessionID) {
+      sessionId = parsed.sessionID;
+    }
+
+    if (parsed.type === 'step_start') {
+      currentStepBuffer = '';
+      continue;
+    }
+
+    if (parsed.type === 'text' && parsed.part?.type === 'text' && typeof parsed.part.text === 'string') {
+      currentStepBuffer += parsed.part.text;
+      hasParseableAssistantText = true;
+      continue;
+    }
+
+    if (parsed.type === 'step_finish') {
+      hasStepFinish = true;
+      latestCompletedStep = {
+        message: currentStepBuffer,
+        session_id: sessionId || undefined,
+        tokens: parsed.part?.tokens,
+        cost: parsed.part?.cost,
+      };
+    }
+  }
+
+  if (hasStepFinish && latestCompletedStep) {
+    return latestCompletedStep;
+  }
+
+  if (hasParseableAssistantText) {
+    return {
+      message: currentStepBuffer,
+      session_id: sessionId || undefined,
+    };
+  }
+
+  return null;
 }

--- a/src/process-result.ts
+++ b/src/process-result.ts
@@ -45,6 +45,10 @@ function hasMeaningfulParsedOutput(agentOutput: any): boolean {
   });
 }
 
+function shouldPreserveRawFailureOutput(context: ProcessResultContext): boolean {
+  return context.agent === 'opencode' && context.status === 'failed';
+}
+
 export function buildProcessResult(context: ProcessResultContext, agentOutput: any, verbose = false): any {
   const response: any = {
     pid: context.pid,
@@ -65,14 +69,19 @@ export function buildProcessResult(context: ProcessResultContext, agentOutput: a
   }
 
   const shapedAgentOutput = verbose ? agentOutput : compactAgentOutput(agentOutput);
+  const preserveRawFailureOutput = shouldPreserveRawFailureOutput(context);
 
-  if (hasMeaningfulParsedOutput(shapedAgentOutput)) {
+  if (hasMeaningfulParsedOutput(shapedAgentOutput) && (verbose || !preserveRawFailureOutput)) {
     response.agentOutput = shapedAgentOutput;
   }
 
-  if (!response.agentOutput) {
+  if (!response.agentOutput || preserveRawFailureOutput) {
     response.stdout = context.stdout;
     response.stderr = context.stderr;
+  }
+
+  if (verbose && preserveRawFailureOutput && hasMeaningfulParsedOutput(shapedAgentOutput)) {
+    response.agentOutput = shapedAgentOutput;
   }
 
   return response;

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,9 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput } from './parsers.js';
 import { buildProcessResult } from './process-result.js';
 
-export type AgentType = 'claude' | 'codex' | 'gemini' | 'forge';
+export type AgentType = 'claude' | 'codex' | 'gemini' | 'forge' | 'opencode';
 export type ProcessStatus = 'running' | 'completed' | 'failed';
 
 interface TrackedProcess {
@@ -35,6 +35,31 @@ export interface StartProcessResult {
 
 interface ProcessServiceOptions {
   cliPaths: BuildCliCommandOptions['cliPaths'];
+}
+
+function parseAgentOutput(agent: AgentType, stdout: string, stderr: string): any {
+  if (agent === 'codex') {
+    return parseCodexOutput(`${stdout || ''}\n${stderr || ''}`);
+  }
+
+  if (!stdout) {
+    return null;
+  }
+
+  if (agent === 'claude') {
+    return parseClaudeOutput(stdout);
+  }
+  if (agent === 'gemini') {
+    return parseGeminiOutput(stdout);
+  }
+  if (agent === 'forge') {
+    return parseForgeOutput(stdout);
+  }
+  if (agent === 'opencode') {
+    return parseOpenCodeOutput(stdout);
+  }
+
+  return null;
 }
 
 export class ProcessService {
@@ -136,19 +161,7 @@ export class ProcessService {
       throw new Error(`Process with PID ${pid} not found`);
     }
 
-    let agentOutput: any = null;
-    if (process.toolType === 'codex') {
-      const combinedOutput = (process.stdout || '') + '\n' + (process.stderr || '');
-      agentOutput = parseCodexOutput(combinedOutput);
-    } else if (process.stdout) {
-      if (process.toolType === 'claude') {
-        agentOutput = parseClaudeOutput(process.stdout);
-      } else if (process.toolType === 'gemini') {
-        agentOutput = parseGeminiOutput(process.stdout);
-      } else if (process.toolType === 'forge') {
-        agentOutput = parseForgeOutput(process.stdout);
-      }
-    }
+    const agentOutput = parseAgentOutput(process.toolType, process.stdout, process.stderr);
 
     return buildProcessResult({
       pid,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
-#!/usr/bin/env node
-export { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli } from './cli-utils.js';
+import { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
+export { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
 export { resolveModelAlias } from './cli-builder.js';
 export { ClaudeCodeServer, runMcpServer, spawnAsync } from './app/mcp.js';
 


### PR DESCRIPTION
## Summary

OpenCode CLI を新しい AI バックエンドとして追加します。`opencode run --format json` による非対話 JSON モードで実行し、モデル選択・セッション再開・失敗時の exit status 永続化を実装します。

## Type of Change

- [x] feat: New feature

## Changes

- **OpenCode コマンドビルド**: `opencode run --format json --dir <workFolder> [--session <id>] [--model <provider/model>] <prompt>` の形式でコマンドを構築
  - `opencode`: OpenCode 側の設定済みデフォルトモデルを使用
  - `oc-<provider/model>`: 明示的なプロバイダー/モデル指定（例: `oc-openai/gpt-5.4`）
- **セッション再開**: `--session <session_id>` による in-place resume に対応。明示モデル指定との併用も可能
- **NDJSON パーサー追加** (`parseOpenCodeOutput`): step_start / text / step_finish イベントを解析し、最終ステップの message・session_id・tokens・cost を返す
- **exit status 永続化**: OpenCode バックエンドに限り自然終了時の exit status を `exit-status.json` に保存。成功時は `agentOutput` を返し、失敗時は raw stdout/stderr を保持
- **`OPENCODE_CLI_NAME` 環境変数**: CLI バイナリパスの上書きをサポート
- **`ai-cli models` 更新**: `opencode: ["opencode"]` と `dynamicModelBackends.opencode` を公開
- **`ai-cli doctor` 更新**: OpenCode の利用可否チェックを追加
- **README 更新** (ja/en): OpenCode の機能・モデル指定・制約・CLI 使用例を追記
- **テスト追加**: `opencode-mock.ts` ユーティリティ、parsers / cli-builder / process-service / MCP contract / e2e の各テストを追加・更新

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [x] Manual testing (if applicable)

## Notes

<!-- Any additional context for reviewers -->
- `reasoning_effort` は OpenCode では未サポート（`oc-<provider/model>` を含む）
- 他のバックエンド（Claude, Codex, Gemini, Forge）の detached 実行では従来通り exit code の永続化なし
- `opencode models` で利用可能なバックエンドネイティブなモデルを確認できる
