### PR TITLE
fix: missing readFileSync import in e2e tests

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createTestClient, MCPTestClient } from './utils/mcp-client.js';


### PR DESCRIPTION
## Summary

Fix missing `readFileSync` import in e2e test file that caused a runtime error when the function was used but not imported.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Refactoring
- [ ] docs: Documentation
- [ ] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- Add `readFileSync` to the `node:fs` import in `src/__tests__/e2e.test.ts`

## Test Plan

- [ ] `npm run test:unit` passes
- [ ] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

<!-- Any additional context for reviewers -->
