### PR TITLE
feat: Add peek command for one-shot observation of running agent messages

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,6 +124,7 @@ ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --session-id ses_123 --prompt 
 ai-cli ps
 ai-cli result 12345
 ai-cli result 12345 --verbose
+ai-cli peek 12345 --time 10
 ai-cli wait 12345 --timeout 300
 ai-cli wait 12345 --verbose
 ai-cli kill 12345
@@ -178,6 +179,7 @@ macOSでは、これらのツールを初めて実行する際にフォルダへ
 - `run`
 - `ps`
 - `result`
+- `peek`
 - `wait`
 - `kill`
 - `cleanup`
@@ -194,6 +196,8 @@ ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
 ai-cli run --cwd "$PWD" --model opencode --session-id ses_existing --prompt "この OpenCode セッションを継続して"
 ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "明示的な OpenCode モデルで実行"
 ai-cli ps
+ai-cli peek 12345 --time 10
+ai-cli peek 12345 12346 --time 10
 ai-cli wait 12345
 ai-cli wait 12345 --verbose
 ai-cli result 12345
@@ -271,6 +275,60 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
 - `pids` (array of numbers, 必須): 待機するプロセスIDのリスト（`run` ツールから返されたもの）。
 - `timeout` (number, 任意): 最大待機時間（秒）。デフォルトは180秒（3分）です。
 - `verbose` (boolean, 任意): `true` の場合、各結果項目を full 形で返します。デフォルトは `false` です。
+
+### `peek`
+
+実行中の子エージェントを短時間だけ観測し、その `peek` 呼び出しの観測ウィンドウ内で ai-cli-mcp が受理した自然言語メッセージだけを返します。履歴APIではなく、欠落のないストリーミングでもなく、シェルの `stdout` / `stderr` tail でもありません。別々の `peek` 呼び出しの間に出たメッセージは取得できない場合があります。v1 では `--follow` はありません。
+
+CLI v1:
+
+```bash
+ai-cli peek 123 --time 10
+ai-cli peek 123 456 --time 10
+```
+
+**引数:**
+- `pids` (array of numbers, 必須): `run` が返したプロセスIDを 1..32 件指定します。重複したPIDはサーバー側で重複排除され、最初に出た順序が維持されます。未知または管理外のPIDは、呼び出し全体の失敗ではなく、プロセスごとに `not_found` として返されます。
+- `peek_time_sec` (number, 任意): 観測時間（秒）の正の整数です。デフォルトは10秒、最大60秒です。`0`、負数、小数は無効です。
+
+**観測とフィルタリング:**
+- `peek_started_at` と `messages[].ts` は、ai-cli-mcp サーバー側の UTC RFC3339 タイムスタンプです。`peek_started_at` は検証とリスナー登録後に観測ウィンドウが始まった時刻、`messages[].ts` は ai-cli-mcp がメッセージを観測して受理した時刻です。
+- 観測ウィンドウは `peek_time_sec` が経過するか、対象プロセスがすべて終端状態になった時点で終了します。
+- 観測開始前のメッセージは返しません。同じPIDへの同時 `peek` は可能で、それぞれ独立した観測ウィンドウを持つため、メッセージが重複して返ることがあります。
+- 返すのは認識済みの自然言語メッセージだけです。Codex の `agent_message` text、Claude assistant の text content、OpenCode の `type: "text"` かつ `part.type` が `"text"` のイベント、Gemini stream-json の `role` が `"assistant"` の `message` イベントを含めます。raw `stdout` / `stderr`、raw JSONL、reasoning、`tool_use`、`tool_result`、コマンドの `stdout` / `stderr`、command execution メタデータ、token usage、verbose メタデータは除外します。
+- 未知のイベント形状はデフォルトで拒否します。Forge など、自然言語抽出がまだ明示対応されていない管理対象エージェントは、実際のプロセス状態を返しつつ、`messages: []`、`truncated: false`、`error: null` にします。
+- 各PIDごとに、観測ウィンドウ内で最初に観測された50件までを保持します。それ以降のメッセージを捨てた場合は `truncated` が `true` になります。
+- `status` は `running`、`completed`、`failed`、`not_found` のいずれかで、観測ウィンドウ終了時点の状態を表します。
+- `agent` は `claude`、`codex`、`gemini`、`forge`、`opencode`、将来追加される追跡済みエージェント文字列、または `null` です。`null` はプロセスが見つからない、またはエージェント種別を判断できない場合を表します。
+
+レスポンス例:
+
+```json
+{
+  "peek_started_at": "2026-04-11T12:34:56.789Z",
+  "observed_duration_sec": 10.01,
+  "processes": [
+    {
+      "pid": 123,
+      "agent": "codex",
+      "status": "running",
+      "messages": [
+        { "ts": "2026-04-11T12:34:59.120Z", "text": "I'm checking the implementation." }
+      ],
+      "truncated": false,
+      "error": null
+    },
+    {
+      "pid": 999,
+      "agent": null,
+      "status": "not_found",
+      "messages": [],
+      "truncated": false,
+      "error": "process not found"
+    }
+  ]
+}
+```
 
 ### `list_processes`
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --session-id ses_123 --prompt 
 ai-cli ps
 ai-cli result 12345
 ai-cli result 12345 --verbose
+ai-cli peek 12345 --time 10
 ai-cli wait 12345 --timeout 300
 ai-cli wait 12345 --verbose
 ai-cli kill 12345
@@ -175,6 +176,7 @@ macOS might ask for folder permissions the first time any of these tools run. If
 - `run`
 - `ps`
 - `result`
+- `peek`
 - `wait`
 - `kill`
 - `cleanup`
@@ -191,6 +193,8 @@ ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
 ai-cli run --cwd "$PWD" --model opencode --session-id ses_existing --prompt "continue this OpenCode session"
 ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "run with an explicit OpenCode backend model"
 ai-cli ps
+ai-cli peek 12345 --time 10
+ai-cli peek 12345 12346 --time 10
 ai-cli wait 12345
 ai-cli wait 12345 --verbose
 ai-cli result 12345
@@ -268,6 +272,60 @@ By default, each returned result item uses the compact shape shared with `get_re
 - `pids` (array of numbers, required): List of process IDs to wait for (returned by the `run` tool).
 - `timeout` (number, optional): Maximum wait time in seconds. Defaults to 180 (3 minutes).
 - `verbose` (boolean, optional): If `true`, each result item uses the full result shape. Defaults to `false`.
+
+### `peek`
+
+Starts a one-shot short observation window for running child agents and returns only natural-language agent messages observed during that specific call. It is not a history API, not gapless streaming, and not shell stdout/stderr tailing. Separate `peek` calls may miss messages emitted between calls; `--follow` is intentionally not part of v1.
+
+CLI v1:
+
+```bash
+ai-cli peek 123 --time 10
+ai-cli peek 123 456 --time 10
+```
+
+**Arguments:**
+- `pids` (array of numbers, required): 1..32 process IDs returned by `run`. Duplicate PIDs are deduplicated server-side, preserving first occurrence order. Unknown or unmanaged PIDs are returned per process as `not_found`, not as a whole-call failure.
+- `peek_time_sec` (number, optional): Positive integer observation length in seconds. Defaults to 10 and is capped at 60. `0`, negative values, and fractional values are invalid.
+
+**Observation and filtering:**
+- `peek_started_at` and `messages[].ts` are ai-cli-mcp server-side UTC RFC3339 timestamps. `peek_started_at` is when the observation window starts after validation and listener registration; `messages[].ts` is when ai-cli-mcp observed and accepted the message.
+- The window ends when `peek_time_sec` elapses or all target processes reach a terminal state, whichever comes first.
+- Messages emitted before the window starts are not returned. Concurrent `peek` calls for the same PID are allowed; each has an independent window and may return overlapping messages.
+- Only recognized natural-language agent messages are returned: Codex `agent_message` text, Claude assistant text content, OpenCode `type: "text"` events where `part.type` is `"text"`, and Gemini stream-json `message` events where `role` is `"assistant"`. Raw stdout/stderr, raw JSONL, reasoning, `tool_use`, `tool_result`, command stdout/stderr, command execution metadata, token usage, and verbose metadata are excluded.
+- Unknown event shapes are denied by default. Managed agents without supported natural-language extraction, such as Forge until explicitly supported, return their real process status with `messages: []`, `truncated: false`, and `error: null`.
+- Each PID keeps the first 50 messages observed in the window. If later messages are dropped, `truncated` is `true`.
+- `status` is one of `running`, `completed`, `failed`, or `not_found`, and reflects state when the observation window closes.
+- `agent` is `claude`, `codex`, `gemini`, `forge`, `opencode`, a future tracked string value, or `null` when the process is not found or the agent cannot be determined.
+
+Example response:
+
+```json
+{
+  "peek_started_at": "2026-04-11T12:34:56.789Z",
+  "observed_duration_sec": 10.01,
+  "processes": [
+    {
+      "pid": 123,
+      "agent": "codex",
+      "status": "running",
+      "messages": [
+        { "ts": "2026-04-11T12:34:59.120Z", "text": "I'm checking the implementation." }
+      ],
+      "truncated": false,
+      "error": null
+    },
+    {
+      "pid": 999,
+      "agent": null,
+      "status": "not_found",
+      "messages": [],
+      "truncated": false,
+      "error": "process not found"
+    }
+  ]
+}
+```
 
 ### `list_processes`
 

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -3,6 +3,7 @@ import {
   CLI_HELP_TEXT,
   DOCTOR_HELP_TEXT,
   MODELS_HELP_TEXT,
+  PEEK_HELP_TEXT,
   RESULT_HELP_TEXT,
   RUN_HELP_TEXT,
   WAIT_HELP_TEXT,
@@ -199,6 +200,64 @@ describe('ai-cli app', () => {
     expect(waitForProcesses).not.toHaveBeenCalled();
   });
 
+  it('dispatches peek with deduped pid arguments and time', async () => {
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+    const peekProcesses = vi.fn().mockResolvedValue({
+      peek_started_at: '2026-04-11T12:34:56.789Z',
+      observed_duration_sec: 0.01,
+      processes: [],
+    });
+
+    const exitCode = await runCli(
+      ['peek', '123', '456', '123', '--time', '5'],
+      {
+        stdout,
+        stderr,
+        peekProcesses,
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(peekProcesses).toHaveBeenCalledWith([123, 456], 5);
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"peek_started_at"'));
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('defaults peek time and rejects --follow', async () => {
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+    const peekProcesses = vi.fn().mockResolvedValue({
+      peek_started_at: '2026-04-11T12:34:56.789Z',
+      observed_duration_sec: 0.01,
+      processes: [],
+    });
+
+    const defaultExitCode = await runCli(['peek', '123'], { stdout, stderr, peekProcesses });
+    expect(defaultExitCode).toBe(0);
+    expect(peekProcesses).toHaveBeenCalledWith([123], 10);
+
+    const followExitCode = await runCli(['peek', '123', '--follow'], { stdout, stderr, peekProcesses });
+    expect(followExitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith('peek does not support --follow in v1\n');
+  });
+
+  it('rejects invalid peek time values', async () => {
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+    const peekProcesses = vi.fn();
+
+    const exitCode = await runCli(['peek', '123', '--time', '1.5'], {
+      stdout,
+      stderr,
+      peekProcesses,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('peek_time_sec must be a positive integer'));
+    expect(peekProcesses).not.toHaveBeenCalled();
+  });
+
   it('dispatches ps, result, and kill', async () => {
     const stdout = vi.fn();
     const stderr = vi.fn();
@@ -351,6 +410,18 @@ describe('ai-cli app', () => {
     expect(stdout).toHaveBeenCalledWith(WAIT_HELP_TEXT);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('compact shape'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('--verbose'));
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('prints detailed help for peek --help', async () => {
+    const stdout = vi.fn();
+    const stderr = vi.fn();
+
+    const exitCode = await runCli(['peek', '--help'], { stdout, stderr });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toHaveBeenCalledWith(PEEK_HELP_TEXT);
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('No --follow mode'));
     expect(stderr).not.toHaveBeenCalled();
   });
 

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -388,7 +388,7 @@ describe('cli-builder', () => {
         expect(cmd.cliPath).toBe('/usr/bin/gemini');
         expect(cmd.args).toContain('-y');
         expect(cmd.args).toContain('--output-format');
-        expect(cmd.args).toContain('json');
+        expect(cmd.args).toContain('stream-json');
         expect(cmd.args).toContain('--model');
         expect(cmd.args).toContain('gemini-2.5-pro');
       });

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -122,6 +122,74 @@ describe('CliProcessService', () => {
     expect(readFileSync(join(processDir, 'meta.json'), 'utf-8')).toContain('"status": "completed"');
   });
 
+  it('peeks only appended natural-language messages from detached logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
+    tempDirs.push(root);
+    const scriptPath = join(root, 'mock-claude-peek');
+    writeFileSync(
+      scriptPath,
+      `#!/bin/bash
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"old cli message"}]}}'
+sleep 2
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"new cli message"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/a"}}]}}'
+printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"secret"}]}}'
+`
+    );
+    chmodSync(scriptPath, 0o755);
+    const stateDir = join(root, 'state');
+    const workFolder = join(root, 'work');
+    mkdirSync(workFolder, { recursive: true });
+
+    const service = new CliProcessService({
+      stateDir,
+      cliPaths: {
+        claude: scriptPath,
+        codex: scriptPath,
+        gemini: scriptPath,
+        forge: scriptPath,
+        opencode: scriptPath,
+      },
+    });
+
+    const runResult = await service.startProcess({
+      prompt: 'hello peek',
+      cwd: workFolder,
+    });
+
+    const processDir = join(stateDir, 'cwds', encodeCwd(realpathSync(workFolder)), String(runResult.pid));
+    const stdoutPath = join(processDir, 'stdout.log');
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 5000 && !readFileSync(stdoutPath, 'utf-8').includes('old cli message')) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(readFileSync(stdoutPath, 'utf-8')).toContain('old cli message');
+
+    const peekResult = await service.peekProcesses([runResult.pid, runResult.pid, 999999], 3);
+
+    expect(peekResult.processes).toHaveLength(2);
+    expect(peekResult.processes[0]).toMatchObject({
+      pid: runResult.pid,
+      agent: 'claude',
+      status: 'completed',
+      messages: [
+        {
+          ts: expect.any(String),
+          text: 'new cli message',
+        },
+      ],
+      truncated: false,
+      error: null,
+    });
+    expect(peekResult.processes[1]).toEqual({
+      pid: 999999,
+      agent: null,
+      status: 'not_found',
+      messages: [],
+      truncated: false,
+      error: 'process not found',
+    });
+  });
+
   it('returns compact results by default and full results when verbose is true', async () => {
     const root = mkdtempSync(join(tmpdir(), 'ai-cli-cli-service-'));
     tempDirs.push(root);

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -39,7 +39,7 @@ describe('Claude Code MCP E2E Tests', () => {
     it('should register run tool', async () => {
       const tools = await client.listTools();
       
-      expect(tools).toHaveLength(6);
+      expect(tools).toHaveLength(7);
       const claudeCodeTool = tools.find((t: any) => t.name === 'run');
       expect(claudeCodeTool.inputSchema.properties.model.description).toContain('sonnet');
       expect(claudeCodeTool.inputSchema.properties.model.description).toContain('opencode');
@@ -49,6 +49,7 @@ describe('Claude Code MCP E2E Tests', () => {
       // Verify other tools exist
       expect(tools.some((t: any) => t.name === 'list_processes')).toBe(true);
       expect(tools.some((t: any) => t.name === 'get_result')).toBe(true);
+      expect(tools.some((t: any) => t.name === 'peek')).toBe(true);
       expect(tools.some((t: any) => t.name === 'kill_process')).toBe(true);
     });
   });

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -96,6 +96,7 @@ describe('MCP Contract Tests', () => {
       'get_result',
       'kill_process',
       'list_processes',
+      'peek',
       'run',
       'wait',
     ]);
@@ -132,6 +133,14 @@ describe('MCP Contract Tests', () => {
       'timeout',
       'verbose',
     ]);
+
+    const peekTool = tools.find((tool: any) => tool.name === 'peek');
+    expect(peekTool.inputSchema.required).toEqual(['pids']);
+    expect(Object.keys(peekTool.inputSchema.properties).sort()).toEqual([
+      'peek_time_sec',
+      'pids',
+    ]);
+    expect(peekTool.description).toContain('One-shot');
   });
 
   it('preserves the stdio MCP smoke flow and response shapes', async () => {

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCodexOutput, parseClaudeOutput, parseForgeOutput, parseOpenCodeOutput } from '../parsers.js';
+import { parseCodexOutput, parseClaudeOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekMessageExtractor } from '../parsers.js';
 
 describe('parseCodexOutput', () => {
   it('should parse basic Codex output with message and session_id', () => {
@@ -62,6 +62,193 @@ INVALID_JSON
 `;
     const result = parseCodexOutput(output);
     expect(result.message).toBe("Still parses valid lines");
+  });
+});
+
+describe('PeekMessageExtractor', () => {
+  const ts = '2026-04-11T12:34:56.789Z';
+
+  it('extracts only Codex agent_message text', () => {
+    const extractor = new PeekMessageExtractor('codex');
+    const output = [
+      '{"type":"item.completed","item":{"type":"reasoning","text":"hidden"}}',
+      '{"type":"item.completed","item":{"type":"command_execution","aggregated_output":"secret command output"}}',
+      '{"type":"item.completed","item":{"type":"agent_message","text":"Visible Codex message"}}',
+      '{"msg":{"type":"token_count","total":123}}',
+      '{"msg":{"type":"agent_message","message":"Visible legacy Codex message"}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      { ts, text: 'Visible Codex message' },
+      { ts, text: 'Visible legacy Codex message' },
+    ]);
+  });
+
+  it('extracts only Claude assistant text content', () => {
+    const extractor = new PeekMessageExtractor('claude');
+    const output = [
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"Visible Claude text"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/a"}}]}}',
+      '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"secret"}]}}',
+      '{"type":"result","result":"Final result is not peek assistant text"}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      { ts, text: 'Visible Claude text' },
+    ]);
+  });
+
+  it('extracts only Gemini assistant message content', () => {
+    const extractor = new PeekMessageExtractor('gemini');
+    const output = [
+      '{"type":"message","timestamp":"2026-04-11T14:44:42.294Z","role":"user","content":"hidden user text"}',
+      '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"Visible Gemini text","delta":true}',
+      '{"type":"tool_use","timestamp":"2026-04-11T14:44:53.821Z","tool_name":"run_shell_command","parameters":{"command":"echo secret"}}',
+      '{"type":"tool_result","timestamp":"2026-04-11T14:45:03.011Z","status":"success","output":"secret command output"}',
+      '{"type":"result","timestamp":"2026-04-11T14:45:10.380Z","status":"success","response":"Final result is not peek assistant text"}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      { ts, text: 'Visible Gemini text' },
+    ]);
+  });
+
+  it('joins split Gemini assistant chunks into one peek message on flush', () => {
+    const extractor = new PeekMessageExtractor('gemini');
+    const output = [
+      '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"Step 2 done. Starting step ","delta":true}',
+      '{"type":"message","timestamp":"2026-04-11T14:44:53.821Z","role":"assistant","content":"3.","delta":true}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([]);
+    expect(extractor.flush('2026-04-11T12:34:59.000Z')).toEqual([
+      { ts: '2026-04-11T12:34:59.000Z', text: 'Step 2 done. Starting step 3.' },
+    ]);
+  });
+
+  it('emits separate Gemini peek messages when a boundary separates logical messages', () => {
+    const extractor = new PeekMessageExtractor('gemini');
+    const output = [
+      '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"Starting step ","delta":true}',
+      '{"type":"message","timestamp":"2026-04-11T14:44:53.821Z","role":"assistant","content":"1.","delta":true}',
+      '{"type":"tool_use","timestamp":"2026-04-11T14:44:53.822Z","tool_name":"run_shell_command","parameters":{"command":"echo secret"}}',
+      '{"type":"tool_result","timestamp":"2026-04-11T14:45:03.011Z","status":"success","output":"secret command output"}',
+      '{"type":"message","timestamp":"2026-04-11T14:45:10.315Z","role":"assistant","content":"Final ","delta":true}',
+      '{"type":"message","timestamp":"2026-04-11T14:45:10.316Z","role":"assistant","content":"answer.","delta":true}',
+      '{"type":"result","timestamp":"2026-04-11T14:45:10.380Z","status":"success","response":"Final result response is not peek text","stats":{"total_tokens":21999}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      { ts, text: 'Starting step 1.' },
+      { ts, text: 'Final answer.' },
+    ]);
+    expect(extractor.flush(ts)).toEqual([]);
+  });
+
+  it('does not emit Gemini user, tool, tool result, stats, or result response text', () => {
+    const extractor = new PeekMessageExtractor('gemini');
+    const output = [
+      '{"type":"message","timestamp":"2026-04-11T14:44:42.294Z","role":"user","content":"hidden user text"}',
+      '{"type":"tool_use","timestamp":"2026-04-11T14:44:53.821Z","tool_name":"run_shell_command","parameters":{"command":"echo secret"}}',
+      '{"type":"tool_result","timestamp":"2026-04-11T14:45:03.011Z","status":"success","output":"secret command output"}',
+      '{"type":"result","timestamp":"2026-04-11T14:45:10.380Z","status":"success","response":"Final result response is not peek text","stats":{"total_tokens":21999}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([]);
+    expect(extractor.flush(ts)).toEqual([]);
+  });
+
+  it('denies unsupported agents and invalid shapes by default', () => {
+    const extractor = new PeekMessageExtractor('forge');
+    const output = [
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"not supported here"}]}}',
+      '{"type":"item.completed","item":{"type":"agent_message","text":"not supported here"}}',
+      '{"type":"text","part":{"type":"text","text":"not supported here"}}',
+      '{"type":"message","role":"assistant","content":"not supported here"}',
+      'plain stdout',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([]);
+  });
+
+  it('extracts only OpenCode natural-language text events', () => {
+    const extractor = new PeekMessageExtractor('opencode');
+    const output = [
+      '{"type":"text","timestamp":1775918783605,"sessionID":"ses-1","part":{"type":"text","text":"OpenCode visible text"}}',
+      '{"type":"tool_use","timestamp":1775918783606,"sessionID":"ses-1","part":{"type":"tool","state":{"output":"secret command output"},"metadata":{"output":"secret metadata output"}}}',
+      '{"type":"text","timestamp":1775918783607,"sessionID":"ses-1","part":{"type":"tool","text":"wrong part type"}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      { ts, text: 'OpenCode visible text' },
+    ]);
+  });
+
+  it('can flush a complete JSON event without a trailing newline', () => {
+    const extractor = new PeekMessageExtractor('codex');
+    expect(extractor.push('{"type":"item.completed","item":{"type":"agent_message","text":"pending"}}', ts)).toEqual([]);
+    expect(extractor.flush(ts)).toEqual([{ ts, text: 'pending' }]);
+  });
+});
+
+describe('parseGeminiOutput', () => {
+  it('should parse legacy final JSON output', () => {
+    const output = JSON.stringify({
+      session_id: 'gemini-session-json',
+      response: 'Legacy Gemini final response',
+      stats: {
+        total_tokens: 123,
+      },
+    });
+
+    expect(parseGeminiOutput(output)).toEqual({
+      session_id: 'gemini-session-json',
+      response: 'Legacy Gemini final response',
+      stats: {
+        total_tokens: 123,
+      },
+    });
+  });
+
+  it('should normalize a single-line Gemini assistant stream event', () => {
+    const output = '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"Only answer","delta":true}';
+
+    const result = parseGeminiOutput(output);
+
+    expect(result).toMatchObject({
+      message: 'Only answer',
+      session_id: null,
+    });
+    expect(result).not.toHaveProperty('type');
+    expect(result).not.toHaveProperty('content');
+  });
+
+  it('should parse Gemini stream-json NDJSON output', () => {
+    const output = [
+      '{"type":"init","timestamp":"2026-04-11T14:44:42.293Z","session_id":"gemini-session-stream","model":"gemini-3.1-pro-preview"}',
+      '{"type":"message","timestamp":"2026-04-11T14:44:42.294Z","role":"user","content":"hidden user text"}',
+      '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"First logical assistant response.","delta":true}',
+      '{"type":"tool_use","timestamp":"2026-04-11T14:44:53.821Z","tool_name":"run_shell_command","tool_id":"tool-1","parameters":{"command":"echo hidden"}}',
+      '{"type":"tool_result","timestamp":"2026-04-11T14:45:03.011Z","tool_id":"tool-1","status":"success","output":"hidden command output"}',
+      '{"type":"message","timestamp":"2026-04-11T14:45:10.315Z","role":"assistant","content":"Final assistant ","delta":true}',
+      '{"type":"message","timestamp":"2026-04-11T14:45:10.316Z","role":"assistant","content":"response.","delta":true}',
+      '{"type":"result","timestamp":"2026-04-11T14:45:10.380Z","status":"success","response":"Result response is not the parsed message","stats":{"total_tokens":21999}}',
+    ].join('\n') + '\n';
+
+    expect(parseGeminiOutput(output)).toEqual({
+      message: 'Final assistant response.',
+      session_id: 'gemini-session-stream',
+      stats: {
+        total_tokens: 21999,
+      },
+      tools: [
+        {
+          tool: 'run_shell_command',
+          input: { command: 'echo hidden' },
+          output: 'hidden command output',
+          status: 'success',
+        },
+      ],
+    });
   });
 });
 

--- a/src/__tests__/peek.test.ts
+++ b/src/__tests__/peek.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { appendPeekMessages, validatePeekPids, validatePeekTimeSec, type PeekProcessResult } from '../peek.js';
+
+describe('peek helpers', () => {
+  it('dedupes pids while preserving first occurrence order', () => {
+    expect(validatePeekPids([3, 1, 3, 2, 1])).toEqual([3, 1, 2]);
+  });
+
+  it('validates pid and time limits', () => {
+    expect(() => validatePeekPids([])).toThrow(/1..32/);
+    expect(() => validatePeekPids([1.5])).toThrow(/positive safe integers/);
+    expect(() => validatePeekPids([Number.MAX_SAFE_INTEGER + 1])).toThrow(/positive safe integers/);
+    expect(validatePeekTimeSec(undefined)).toBe(10);
+    expect(validatePeekTimeSec(60)).toBe(60);
+    expect(() => validatePeekTimeSec(0)).toThrow(/positive integer/);
+    expect(() => validatePeekTimeSec(1.5)).toThrow(/positive integer/);
+    expect(() => validatePeekTimeSec(61)).toThrow(/positive integer/);
+  });
+
+  it('keeps the first 50 messages and marks truncation when later messages are dropped', () => {
+    const process: PeekProcessResult = {
+      pid: 123,
+      agent: 'codex',
+      status: 'running',
+      messages: [],
+      truncated: false,
+      error: null,
+    };
+
+    appendPeekMessages(
+      process,
+      Array.from({ length: 55 }, (_, index) => ({
+        ts: '2026-04-11T12:34:56.789Z',
+        text: `message ${index}`,
+      })),
+    );
+
+    expect(process.messages).toHaveLength(50);
+    expect(process.messages[0].text).toBe('message 0');
+    expect(process.messages[49].text).toBe('message 49');
+    expect(process.truncated).toBe(true);
+  });
+});

--- a/src/__tests__/process-management.test.ts
+++ b/src/__tests__/process-management.test.ts
@@ -118,6 +118,190 @@ describe('Process Management Tests', () => {
       expect(response.message).toBe('claude process started successfully');
     });
 
+    it('should peek only natural-language messages observed after registration', async () => {
+      const { handlers } = await setupServer();
+
+      const mockProcess = new EventEmitter() as any;
+      mockProcess.pid = 12345;
+      mockProcess.stdout = new EventEmitter();
+      mockProcess.stderr = new EventEmitter();
+      mockProcess.kill = vi.fn();
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const callToolHandler = handlers.get('callTool')!;
+      await callToolHandler!({
+        params: {
+          name: 'run',
+          arguments: {
+            prompt: 'test prompt',
+            workFolder: '/tmp'
+          }
+        }
+      });
+
+      mockProcess.stdout.emit('data', '{"type":"assistant","message":{"content":[{"type":"text","text":"old message"}]}}\n');
+
+      const peekPromise = callToolHandler!({
+        params: {
+          name: 'peek',
+          arguments: {
+            pids: [12345, 12345, 99999],
+            peek_time_sec: 1,
+          }
+        }
+      });
+
+      setTimeout(() => {
+        mockProcess.stdout.emit('data', '{"type":"assistant","message":{"content":[{"type":"text","text":"new message"},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"/tmp/a"}}]}}\n');
+        mockProcess.stdout.emit('data', '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"secret"}]}}\n');
+        mockProcess.emit('close', 0);
+      }, 10);
+
+      const result = await peekPromise;
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.processes).toHaveLength(2);
+      expect(response.processes[0]).toMatchObject({
+        pid: 12345,
+        agent: 'claude',
+        status: 'completed',
+        messages: [
+          {
+            ts: expect.any(String),
+            text: 'new message',
+          },
+        ],
+        truncated: false,
+        error: null,
+      });
+      expect(response.processes[1]).toEqual({
+        pid: 99999,
+        agent: null,
+        status: 'not_found',
+        messages: [],
+        truncated: false,
+        error: 'process not found',
+      });
+    });
+
+    it('should peek OpenCode text events and exclude OpenCode tool output', async () => {
+      const { handlers } = await setupServer();
+
+      const mockProcess = new EventEmitter() as any;
+      mockProcess.pid = 12346;
+      mockProcess.stdout = new EventEmitter();
+      mockProcess.stderr = new EventEmitter();
+      mockProcess.kill = vi.fn();
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const callToolHandler = handlers.get('callTool')!;
+      await callToolHandler!({
+        params: {
+          name: 'run',
+          arguments: {
+            prompt: 'opencode peek prompt',
+            workFolder: '/tmp',
+            model: 'opencode',
+          }
+        }
+      });
+
+      const peekPromise = callToolHandler!({
+        params: {
+          name: 'peek',
+          arguments: {
+            pids: [12346],
+            peek_time_sec: 1,
+          }
+        }
+      });
+
+      setTimeout(() => {
+        mockProcess.stdout.emit('data', '{"type":"text","timestamp":1775918783605,"sessionID":"ses-1","part":{"type":"text","text":"OpenCode visible text"}}\n');
+        mockProcess.stdout.emit('data', '{"type":"tool_use","timestamp":1775918783606,"sessionID":"ses-1","part":{"type":"tool","state":{"output":"secret command output"},"metadata":{"output":"secret metadata output"}}}\n');
+        mockProcess.emit('close', 0);
+      }, 10);
+
+      const result = await peekPromise;
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.processes).toHaveLength(1);
+      expect(response.processes[0]).toMatchObject({
+        pid: 12346,
+        agent: 'opencode',
+        status: 'completed',
+        messages: [
+          {
+            ts: expect.any(String),
+            text: 'OpenCode visible text',
+          },
+        ],
+        truncated: false,
+        error: null,
+      });
+    });
+
+    it('should peek Gemini assistant message events and exclude tool output', async () => {
+      const { handlers } = await setupServer();
+
+      const mockProcess = new EventEmitter() as any;
+      mockProcess.pid = 12347;
+      mockProcess.stdout = new EventEmitter();
+      mockProcess.stderr = new EventEmitter();
+      mockProcess.kill = vi.fn();
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const callToolHandler = handlers.get('callTool')!;
+      await callToolHandler!({
+        params: {
+          name: 'run',
+          arguments: {
+            prompt: 'gemini peek prompt',
+            workFolder: '/tmp',
+            model: 'gemini-2.5-pro',
+          }
+        }
+      });
+
+      const peekPromise = callToolHandler!({
+        params: {
+          name: 'peek',
+          arguments: {
+            pids: [12347],
+            peek_time_sec: 1,
+          }
+        }
+      });
+
+      setTimeout(() => {
+        mockProcess.stdout.emit('data', '{"type":"message","timestamp":"2026-04-11T14:44:42.294Z","role":"user","content":"hidden user text"}\n');
+        mockProcess.stdout.emit('data', '{"type":"message","timestamp":"2026-04-11T14:44:53.820Z","role":"assistant","content":"Visible Gemini text","delta":true}\n');
+        mockProcess.stdout.emit('data', '{"type":"tool_result","timestamp":"2026-04-11T14:45:03.011Z","status":"success","output":"secret command output"}\n');
+        mockProcess.emit('close', 0);
+      }, 10);
+
+      const result = await peekPromise;
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.processes).toHaveLength(1);
+      expect(response.processes[0]).toMatchObject({
+        pid: 12347,
+        agent: 'gemini',
+        status: 'completed',
+        messages: [
+          {
+            ts: expect.any(String),
+            text: 'Visible Gemini text',
+          },
+        ],
+        truncated: false,
+        error: null,
+      });
+    });
+
     it('should handle process with model parameter', async () => {
       const { handlers } = await setupServer();
       

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -497,14 +497,15 @@ describe('ClaudeCodeServer Unit Tests', () => {
       const handler = listToolsCall[1];
       const result = await handler();
       
-      expect(result.tools).toHaveLength(6);
+      expect(result.tools).toHaveLength(7);
       expect(result.tools[0].name).toBe('run');
       expect(result.tools[0].description).toContain('AI Agent Runner');
       expect(result.tools[1].name).toBe('list_processes');
       expect(result.tools[2].name).toBe('get_result');
       expect(result.tools[3].name).toBe('wait');
-      expect(result.tools[4].name).toBe('kill_process');
-      expect(result.tools[5].name).toBe('cleanup_processes');
+      expect(result.tools[4].name).toBe('peek');
+      expect(result.tools[5].name).toBe('kill_process');
+      expect(result.tools[6].name).toBe('cleanup_processes');
     });
 
     it('should handle CallToolRequest', async () => {

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -2,12 +2,14 @@ import { runMcpServer } from './mcp.js';
 import { CliProcessService } from '../cli-process-service.js';
 import { getCliDoctorStatus } from '../cli-utils.js';
 import { getModelsPayload } from '../model-catalog.js';
+import { validatePeekPids, validatePeekTimeSec } from '../peek.js';
 
 export const CLI_HELP_TEXT = `Usage: ai-cli <command> [options]
 
 Commands:
   run       Start an AI CLI process in the background
   wait      Wait for one or more pids
+  peek      Observe new natural-language agent messages for a short window
   ps        List tracked processes
   result    Get the current result for a pid
   kill      Terminate a tracked pid
@@ -55,6 +57,17 @@ Get the current output and status of a tracked process. By default this returns 
 
 Options:
   --verbose                    Return full metadata and detailed parsed output
+  --help, -h                   Show this help message
+`;
+
+export const PEEK_HELP_TEXT = `Usage: ai-cli peek <pid...> [options]
+
+Observe new natural-language agent messages for a short one-shot window.
+In v1, message extraction is supported for Codex, Claude, OpenCode, and Gemini; Forge returns status with messages: [].
+This is not a history API, gapless streaming, or stdout/stderr tailing. No --follow mode is available in v1.
+
+Options:
+  --time <seconds>             Observation window in seconds. Defaults to 10, maximum 60
   --help, -h                   Show this help message
 `;
 
@@ -118,6 +131,7 @@ interface CliDeps {
   listProcesses: () => Promise<any>;
   getProcessResult: (pid: number, verbose: boolean) => Promise<any>;
   waitForProcesses: (pids: number[], timeoutSeconds?: number, verbose?: boolean) => Promise<any>;
+  peekProcesses: (pids: number[], peekTimeSec?: number) => Promise<any>;
   killProcess: (pid: number) => Promise<any>;
   cleanupProcesses: () => Promise<any>;
   getDoctorStatus: () => any;
@@ -140,6 +154,7 @@ const defaultDeps: CliDeps = {
   listProcesses: () => getCliProcessService().listProcesses(),
   getProcessResult: (pid, verbose) => getCliProcessService().getProcessResult(pid, verbose),
   waitForProcesses: (pids, timeoutSeconds, verbose) => getCliProcessService().waitForProcesses(pids, timeoutSeconds, verbose),
+  peekProcesses: (pids, peekTimeSec) => getCliProcessService().peekProcesses(pids, peekTimeSec),
   killProcess: (pid) => getCliProcessService().killProcess(pid),
   cleanupProcesses: () => getCliProcessService().cleanupProcesses(),
   getDoctorStatus: () => getCliDoctorStatus(),
@@ -204,6 +219,10 @@ function hasHelpFlag(flags: Record<string, string>): boolean {
   return 'help' in flags || 'h' in flags;
 }
 
+function parsePeekCliPids(values: string[]): number[] {
+  return validatePeekPids(values.map((value) => Number(value)));
+}
+
 export async function runCli(argv: string[], deps: Partial<CliDeps> = {}): Promise<number> {
   const {
     stdout,
@@ -213,6 +232,7 @@ export async function runCli(argv: string[], deps: Partial<CliDeps> = {}): Promi
     listProcesses,
     getProcessResult,
     waitForProcesses,
+    peekProcesses,
     killProcess,
     cleanupProcesses,
     getDoctorStatus,
@@ -320,6 +340,34 @@ export async function runCli(argv: string[], deps: Partial<CliDeps> = {}): Promi
     }
 
     writeJson(stdout, await waitForProcesses(pids as number[], timeout, 'verbose' in flags));
+    return 0;
+  }
+
+  if (command === 'peek') {
+    const { positionals, flags } = parseArgs(argv.slice(1));
+    if (hasHelpFlag(flags)) {
+      stdout(PEEK_HELP_TEXT);
+      return 0;
+    }
+    if ('follow' in flags) {
+      stderr('peek does not support --follow in v1\n');
+      stdout(CLI_HELP_TEXT);
+      return 1;
+    }
+
+    let pids: number[];
+    let peekTimeSec: number;
+    try {
+      pids = parsePeekCliPids(positionals);
+      const timeRaw = getFirstFlag(flags, ['time']);
+      peekTimeSec = validatePeekTimeSec(timeRaw === undefined ? undefined : Number(timeRaw));
+    } catch (error: any) {
+      stderr(`${error.message}\n`);
+      stdout(CLI_HELP_TEXT);
+      return 1;
+    }
+
+    writeJson(stdout, await peekProcesses(pids, peekTimeSec));
     return 0;
   }
 

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -10,6 +10,7 @@ import {
 import { spawn } from 'node:child_process';
 import { debugLog, findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from '../cli-utils.js';
 import { getModelParameterDescription, getSupportedModelsDescription } from '../model-catalog.js';
+import { validatePeekPids, validatePeekTimeSec } from '../peek.js';
 import { ProcessService } from '../process-service.js';
 
 // Server version - update this when releasing new versions
@@ -231,6 +232,25 @@ ${getSupportedModelsDescription()}
           },
         },
         {
+          name: 'peek',
+          description: 'One-shot short observation window for running child agents. Returns only natural-language agent messages observed during this call; not a history API, not gapless streaming, and not stdout/stderr tailing. In v1, message extraction is supported for Codex, Claude, OpenCode, and Gemini; Forge returns status with messages: [].',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              pids: {
+                type: 'array',
+                items: { type: 'number' },
+                description: 'Process IDs returned by run. Duplicates are deduplicated server-side, preserving first occurrence order. Unknown PIDs are returned per process as not_found.',
+              },
+              peek_time_sec: {
+                type: 'number',
+                description: 'Optional positive integer observation window in seconds. Defaults to 10; maximum is 60.',
+              },
+            },
+            required: ['pids'],
+          },
+        },
+        {
           name: 'kill_process',
           description: 'Terminate a running AI agent process by PID.',
           inputSchema: {
@@ -270,6 +290,8 @@ ${getSupportedModelsDescription()}
           return this.handleGetResult(toolArguments);
         case 'wait':
           return this.handleWait(toolArguments);
+        case 'peek':
+          return this.handlePeek(toolArguments);
         case 'kill_process':
           return this.handleKillProcess(toolArguments);
         case 'cleanup_processes':
@@ -356,6 +378,30 @@ ${getSupportedModelsDescription()}
     } catch (error: any) {
       const code = /not found/.test(error.message) ? ErrorCode.InvalidParams : ErrorCode.InternalError;
       throw new McpError(code, error.message);
+    }
+  }
+
+  private async handlePeek(toolArguments: any): Promise<ServerResult> {
+    let pids: number[];
+    let peekTimeSec: number;
+
+    try {
+      pids = validatePeekPids(toolArguments.pids);
+      peekTimeSec = validatePeekTimeSec(toolArguments.peek_time_sec);
+    } catch (error: any) {
+      throw new McpError(ErrorCode.InvalidParams, error.message);
+    }
+
+    try {
+      const response = await this.processService.peekProcesses(pids, peekTimeSec);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify(response, null, 2)
+        }]
+      };
+    } catch (error: any) {
+      throw new McpError(ErrorCode.InternalError, `Failed to peek processes: ${error.message}`);
     }
   }
 

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -219,7 +219,7 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
     args.push('--skip-git-repo-check', '--full-auto', '--json', prompt);
   } else if (agent === 'gemini') {
     cliPath = options.cliPaths.gemini;
-    args = ['-y', '--output-format', 'json'];
+    args = ['-y', '--output-format', 'stream-json'];
 
     if (options.session_id && typeof options.session_id === 'string') {
       args.push('-r', options.session_id);

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -5,11 +5,13 @@ import {
   existsSync,
   mkdirSync,
   openSync,
+  readSync,
   readFileSync,
   readdirSync,
   realpathSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -17,8 +19,17 @@ import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekMessageExtractor } from './parsers.js';
 import { buildProcessResult } from './process-result.js';
+import {
+  appendPeekMessages,
+  buildNotFoundPeekProcess,
+  observedDurationSec,
+  validatePeekPids,
+  validatePeekTimeSec,
+  type PeekProcessResult,
+  type PeekResponse,
+} from './peek.js';
 import type { AgentType, ProcessListItem } from './process-service.js';
 
 interface StoredProcess {
@@ -244,6 +255,97 @@ export class CliProcessService {
     }
   }
 
+  async peekProcesses(pids: number[], peekTimeSec = 10): Promise<PeekResponse> {
+    const targetPids = validatePeekPids(pids);
+    const targetPeekTimeSec = validatePeekTimeSec(peekTimeSec);
+    const processes: PeekProcessResult[] = [];
+    const observers: Array<{
+      process: StoredProcess;
+      result: PeekProcessResult;
+      stdoutExtractor: PeekMessageExtractor;
+      stderrExtractor: PeekMessageExtractor;
+      stdoutOffset: number;
+      stderrOffset: number;
+    }> = [];
+
+    for (const pid of targetPids) {
+      let process: StoredProcess;
+      try {
+        process = this.refreshStatus(this.readProcess(pid));
+      } catch {
+        processes.push(buildNotFoundPeekProcess(pid));
+        continue;
+      }
+
+      const result: PeekProcessResult = {
+        pid,
+        agent: process.toolType,
+        status: process.status,
+        messages: [],
+        truncated: false,
+        error: null,
+      };
+      processes.push(result);
+      observers.push({
+        process,
+        result,
+        stdoutExtractor: new PeekMessageExtractor(process.toolType),
+        stderrExtractor: new PeekMessageExtractor(process.toolType),
+        stdoutOffset: this.fileSizeSafe(process.stdoutPath),
+        stderrOffset: this.fileSizeSafe(process.stderrPath),
+      });
+    }
+
+    const startedAt = new Date();
+    const startedAtMs = Date.now();
+    const deadlineMs = startedAtMs + targetPeekTimeSec * 1000;
+
+    while (Date.now() <= deadlineMs) {
+      const observedAt = new Date().toISOString();
+      let allTerminal = true;
+
+      for (const observer of observers) {
+        const stdoutRead = this.readTextFromOffset(observer.process.stdoutPath, observer.stdoutOffset);
+        observer.stdoutOffset = stdoutRead.offset;
+        appendPeekMessages(observer.result, observer.stdoutExtractor.push(stdoutRead.text, observedAt));
+
+        const stderrRead = this.readTextFromOffset(observer.process.stderrPath, observer.stderrOffset);
+        observer.stderrOffset = stderrRead.offset;
+        appendPeekMessages(observer.result, observer.stderrExtractor.push(stderrRead.text, observedAt));
+
+        observer.process = this.refreshStatus(this.readProcess(observer.process.pid));
+        observer.result.status = observer.process.status;
+        if (observer.process.status === 'running') {
+          allTerminal = false;
+        }
+      }
+
+      if (allTerminal) {
+        break;
+      }
+
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, Math.min(50, remainingMs)));
+    }
+
+    const flushTs = new Date().toISOString();
+    for (const observer of observers) {
+      observer.process = this.refreshStatus(this.readProcess(observer.process.pid));
+      observer.result.status = observer.process.status;
+      appendPeekMessages(observer.result, observer.stdoutExtractor.flush(flushTs));
+      appendPeekMessages(observer.result, observer.stderrExtractor.flush(flushTs));
+    }
+
+    return {
+      peek_started_at: startedAt.toISOString(),
+      observed_duration_sec: observedDurationSec(startedAtMs),
+      processes,
+    };
+  }
+
   async killProcess(pid: number): Promise<{ pid: number; status: string; message: string }> {
     const process = this.readProcess(pid);
     const refreshed = this.refreshStatus(process);
@@ -443,6 +545,37 @@ export class CliProcessService {
       return '';
     }
     return readFileSync(filePath, 'utf-8');
+  }
+
+  private fileSizeSafe(filePath: string): number {
+    if (!existsSync(filePath)) {
+      return 0;
+    }
+    return statSync(filePath).size;
+  }
+
+  private readTextFromOffset(filePath: string, offset: number): { text: string; offset: number } {
+    if (!existsSync(filePath)) {
+      return { text: '', offset };
+    }
+
+    const size = statSync(filePath).size;
+    if (size <= offset) {
+      return { text: '', offset: size };
+    }
+
+    const fd = openSync(filePath, 'r');
+    try {
+      const length = size - offset;
+      const buffer = Buffer.alloc(length);
+      const bytesRead = readSync(fd, buffer, 0, length, offset);
+      return {
+        text: buffer.subarray(0, bytesRead).toString('utf-8'),
+        offset: size,
+      };
+    } finally {
+      closeSync(fd);
+    }
   }
 
   private resolveCwdsDir(): string {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,5 +1,131 @@
 import { debugLog } from './cli-utils.js';
 
+export interface PeekMessage {
+  ts: string;
+  text: string;
+}
+
+type PeekAgent = 'claude' | 'codex' | string | null;
+
+function isGeminiAssistantMessageEvent(parsed: any): boolean {
+  return parsed.type === 'message' && parsed.role === 'assistant' && typeof parsed.content === 'string';
+}
+
+const GEMINI_STREAM_EVENT_TYPES = new Set([
+  'init',
+  'message',
+  'tool_use',
+  'tool_result',
+  'result',
+  'error',
+  'stats',
+]);
+
+function isGeminiStreamJsonEvent(parsed: any): boolean {
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) && GEMINI_STREAM_EVENT_TYPES.has(parsed.type);
+}
+
+function extractPeekMessagesFromParsedEvent(agent: PeekAgent, parsed: any, observedAt: string): PeekMessage[] {
+  if (agent === 'codex') {
+    if (parsed.item?.type === 'agent_message' && typeof parsed.item.text === 'string' && parsed.item.text.trim()) {
+      return [{ ts: observedAt, text: parsed.item.text }];
+    }
+    if (parsed.msg?.type === 'agent_message' && typeof parsed.msg.message === 'string' && parsed.msg.message.trim()) {
+      return [{ ts: observedAt, text: parsed.msg.message }];
+    }
+    return [];
+  }
+
+  if (agent === 'claude' && parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
+    return parsed.message.content
+      .filter((content: any) => content?.type === 'text' && typeof content.text === 'string' && content.text.trim())
+      .map((content: any) => ({ ts: observedAt, text: content.text }));
+  }
+
+  if (agent === 'opencode' && parsed.type === 'text' && parsed.part?.type === 'text' && typeof parsed.part.text === 'string' && parsed.part.text.trim()) {
+    return [{ ts: observedAt, text: parsed.part.text }];
+  }
+
+  return [];
+}
+
+export class PeekMessageExtractor {
+  private pending = '';
+  private geminiAssistantBuffer = '';
+
+  constructor(private readonly agent: PeekAgent) {}
+
+  push(chunk: string, observedAt = new Date().toISOString()): PeekMessage[] {
+    if (!chunk) {
+      return [];
+    }
+
+    const lines = `${this.pending}${chunk}`.split(/\r?\n/);
+    this.pending = lines.pop() || '';
+    return this.extractLines(lines, observedAt);
+  }
+
+  flush(observedAt = new Date().toISOString()): PeekMessage[] {
+    const messages: PeekMessage[] = [];
+
+    if (this.pending) {
+      const line = this.pending;
+      this.pending = '';
+      messages.push(...this.extractLines([line], observedAt));
+    }
+
+    messages.push(...this.flushGeminiAssistantBuffer(observedAt));
+    return messages;
+  }
+
+  private extractLines(lines: string[], observedAt: string): PeekMessage[] {
+    const messages: PeekMessage[] = [];
+
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+
+      try {
+        messages.push(...this.extractParsedEvent(JSON.parse(line), observedAt));
+      } catch {
+        debugLog(`[Debug] Skipping invalid peek JSON line: ${line}`);
+        messages.push(...this.flushGeminiAssistantBuffer(observedAt));
+      }
+    }
+
+    return messages;
+  }
+
+  private extractParsedEvent(parsed: any, observedAt: string): PeekMessage[] {
+    if (this.agent !== 'gemini') {
+      return extractPeekMessagesFromParsedEvent(this.agent, parsed, observedAt);
+    }
+
+    if (isGeminiAssistantMessageEvent(parsed)) {
+      this.geminiAssistantBuffer += parsed.content;
+      return [];
+    }
+
+    return this.flushGeminiAssistantBuffer(observedAt);
+  }
+
+  private flushGeminiAssistantBuffer(observedAt: string): PeekMessage[] {
+    if (this.agent !== 'gemini' || !this.geminiAssistantBuffer) {
+      return [];
+    }
+
+    const text = this.geminiAssistantBuffer;
+    this.geminiAssistantBuffer = '';
+
+    if (!text.trim()) {
+      return [];
+    }
+
+    return [{ ts: observedAt, text }];
+  }
+}
+
 export function parseCodexOutput(stdout: string): any {
   if (!stdout) return null;
 
@@ -142,11 +268,105 @@ export function parseGeminiOutput(stdout: string): any {
   if (!stdout) return null;
 
   try {
-    return JSON.parse(stdout);
+    const parsed = JSON.parse(stdout.trim());
+    if (!isGeminiStreamJsonEvent(parsed)) {
+      return parsed;
+    }
   } catch (e) {
     debugLog(`[Debug] Failed to parse Gemini JSON output: ${e}`);
-    return null;
   }
+
+  let sessionId: string | null = null;
+  let assistantBuffer = '';
+  let lastMessage: string | null = null;
+  let stats: any = null;
+  const toolsById = new Map<string, any>();
+  const toolsWithoutId: any[] = [];
+  const flushAssistantMessage = () => {
+    if (assistantBuffer.trim()) {
+      lastMessage = assistantBuffer;
+    }
+    assistantBuffer = '';
+  };
+
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(line);
+    } catch (e) {
+      debugLog(`[Debug] Skipping invalid Gemini stream-json line: ${line}`);
+      flushAssistantMessage();
+      continue;
+    }
+
+    if (parsed.type === 'init' && typeof parsed.session_id === 'string' && parsed.session_id) {
+      sessionId = parsed.session_id;
+      continue;
+    }
+
+    if (isGeminiAssistantMessageEvent(parsed)) {
+      assistantBuffer += parsed.content;
+      continue;
+    }
+
+    flushAssistantMessage();
+
+    if (parsed.type === 'result') {
+      if (parsed.stats) {
+        stats = parsed.stats;
+      }
+      continue;
+    }
+
+    if (parsed.type === 'tool_use') {
+      const tool = {
+        tool: parsed.tool_name || parsed.name || 'tool_use',
+        input: parsed.parameters ?? parsed.input ?? null,
+        output: null,
+        status: null,
+      };
+      if (typeof parsed.tool_id === 'string' && parsed.tool_id) {
+        toolsById.set(parsed.tool_id, tool);
+      } else {
+        toolsWithoutId.push(tool);
+      }
+      continue;
+    }
+
+    if (parsed.type === 'tool_result') {
+      const toolId = typeof parsed.tool_id === 'string' ? parsed.tool_id : '';
+      const tool = toolId ? toolsById.get(toolId) : null;
+      if (tool) {
+        tool.output = parsed.output ?? parsed.result ?? null;
+        tool.status = parsed.status ?? null;
+      } else {
+        toolsWithoutId.push({
+          tool: 'tool_result',
+          input: null,
+          output: parsed.output ?? parsed.result ?? null,
+          status: parsed.status ?? null,
+        });
+      }
+    }
+  }
+
+  flushAssistantMessage();
+  const tools = [...toolsById.values(), ...toolsWithoutId];
+
+  if (lastMessage || sessionId || stats || tools.length > 0) {
+    return {
+      message: lastMessage,
+      session_id: sessionId,
+      stats: stats || undefined,
+      tools: tools.length > 0 ? tools : undefined,
+    };
+  }
+
+  return null;
 }
 
 export function parseForgeOutput(stdout: string): any {

--- a/src/peek.ts
+++ b/src/peek.ts
@@ -1,0 +1,88 @@
+import type { PeekMessage } from './parsers.js';
+import type { AgentType, ProcessStatus } from './process-service.js';
+
+export const DEFAULT_PEEK_TIME_SEC = 10;
+export const MAX_PEEK_TIME_SEC = 60;
+export const MAX_PEEK_PIDS = 32;
+export const PEEK_MESSAGE_CAP = 50;
+
+export type PeekStatus = ProcessStatus | 'not_found';
+export type PeekAgent = AgentType | string | null;
+
+export interface PeekProcessResult {
+  pid: number;
+  agent: PeekAgent;
+  status: PeekStatus;
+  messages: PeekMessage[];
+  truncated: boolean;
+  error: string | null;
+}
+
+export interface PeekResponse {
+  peek_started_at: string;
+  observed_duration_sec: number;
+  processes: PeekProcessResult[];
+}
+
+export function validatePeekPids(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Missing or invalid required parameter: pids (must be an array of positive safe integers)');
+  }
+
+  const deduped: number[] = [];
+  const seen = new Set<number>();
+
+  for (const pid of value) {
+    if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) {
+      throw new Error('All pids must be positive safe integers');
+    }
+
+    if (!seen.has(pid)) {
+      seen.add(pid);
+      deduped.push(pid);
+    }
+  }
+
+  if (deduped.length === 0 || deduped.length > MAX_PEEK_PIDS) {
+    throw new Error(`pids must contain 1..${MAX_PEEK_PIDS} entries after dedupe`);
+  }
+
+  return deduped;
+}
+
+export function validatePeekTimeSec(value: unknown): number {
+  if (value === undefined || value === null) {
+    return DEFAULT_PEEK_TIME_SEC;
+  }
+
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0 || value > MAX_PEEK_TIME_SEC) {
+    throw new Error(`peek_time_sec must be a positive integer no greater than ${MAX_PEEK_TIME_SEC}`);
+  }
+
+  return value;
+}
+
+export function buildNotFoundPeekProcess(pid: number): PeekProcessResult {
+  return {
+    pid,
+    agent: null,
+    status: 'not_found',
+    messages: [],
+    truncated: false,
+    error: 'process not found',
+  };
+}
+
+export function appendPeekMessages(target: PeekProcessResult, messages: PeekMessage[]): void {
+  for (const message of messages) {
+    if (target.messages.length < PEEK_MESSAGE_CAP) {
+      target.messages.push(message);
+    } else {
+      target.truncated = true;
+    }
+  }
+}
+
+export function observedDurationSec(startedAtMs: number, endedAtMs = Date.now()): number {
+  return Number(((endedAtMs - startedAtMs) / 1000).toFixed(2));
+}

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,6 +1,15 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekMessageExtractor } from './parsers.js';
+import {
+  appendPeekMessages,
+  buildNotFoundPeekProcess,
+  observedDurationSec,
+  validatePeekPids,
+  validatePeekTimeSec,
+  type PeekProcessResult,
+  type PeekResponse,
+} from './peek.js';
 import { buildProcessResult } from './process-result.js';
 
 export type AgentType = 'claude' | 'codex' | 'gemini' | 'forge' | 'opencode';
@@ -215,6 +224,103 @@ export class ProcessService {
         clearTimeout(timeoutHandle);
       }
     }
+  }
+
+  async peekProcesses(pids: number[], peekTimeSec = 10): Promise<PeekResponse> {
+    const targetPids = validatePeekPids(pids);
+    const targetPeekTimeSec = validatePeekTimeSec(peekTimeSec);
+    const processes: PeekProcessResult[] = [];
+    const observers: Array<{
+      entry: TrackedProcess;
+      result: PeekProcessResult;
+      stdoutExtractor: PeekMessageExtractor;
+      stderrExtractor: PeekMessageExtractor;
+      onStdout: (data: Buffer | string) => void;
+      onStderr: (data: Buffer | string) => void;
+    }> = [];
+
+    for (const pid of targetPids) {
+      const entry = this.processManager.get(pid);
+      if (!entry) {
+        processes.push(buildNotFoundPeekProcess(pid));
+        continue;
+      }
+
+      const result: PeekProcessResult = {
+        pid,
+        agent: entry.toolType,
+        status: entry.status,
+        messages: [],
+        truncated: false,
+        error: null,
+      };
+      processes.push(result);
+
+      const stdoutExtractor = new PeekMessageExtractor(entry.toolType);
+      const stderrExtractor = new PeekMessageExtractor(entry.toolType);
+      const onStdout = (data: Buffer | string) => {
+        appendPeekMessages(result, stdoutExtractor.push(data.toString(), new Date().toISOString()));
+      };
+      const onStderr = (data: Buffer | string) => {
+        appendPeekMessages(result, stderrExtractor.push(data.toString(), new Date().toISOString()));
+      };
+
+      if (entry.status === 'running') {
+        entry.process.stdout?.on('data', onStdout);
+        entry.process.stderr?.on('data', onStderr);
+      }
+
+      observers.push({ entry, result, stdoutExtractor, stderrExtractor, onStdout, onStderr });
+    }
+
+    const startedAt = new Date();
+    const startedAtMs = Date.now();
+    const runningObservers = observers.filter((observer) => observer.entry.status === 'running');
+    const terminalPromise = Promise.all(runningObservers.map((observer) => this.waitForProcessTerminal(observer.entry)));
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutHandle = setTimeout(resolve, targetPeekTimeSec * 1000);
+      timeoutHandle.unref?.();
+    });
+
+    try {
+      await Promise.race([terminalPromise, timeoutPromise]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+
+      const flushTs = new Date().toISOString();
+      for (const observer of observers) {
+        observer.entry.process.stdout?.off('data', observer.onStdout);
+        observer.entry.process.stderr?.off('data', observer.onStderr);
+        appendPeekMessages(observer.result, observer.stdoutExtractor.flush(flushTs));
+        appendPeekMessages(observer.result, observer.stderrExtractor.flush(flushTs));
+        observer.result.status = observer.entry.status;
+      }
+    }
+
+    return {
+      peek_started_at: startedAt.toISOString(),
+      observed_duration_sec: observedDurationSec(startedAtMs),
+      processes,
+    };
+  }
+
+  private waitForProcessTerminal(processEntry: TrackedProcess): Promise<void> {
+    if (processEntry.status !== 'running') {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      const done = () => {
+        processEntry.process.off('close', done);
+        processEntry.process.off('error', done);
+        resolve();
+      };
+      processEntry.process.once('close', done);
+      processEntry.process.once('error', done);
+    });
   }
 
   killProcess(pid: number): { pid: number; status: string; message: string } {


### PR DESCRIPTION
## Summary

Add `peek` command: a one-shot observation window that returns natural-language messages from running child agents without polling history or streaming stdout.

## Type of Change

- [x] feat: New feature

## Changes

- Added `peek` CLI command (`ai-cli peek <pids...> --time <sec>`) with PID deduplication and `--follow` rejection
- Added `peekProcesses()` method to `CliProcessService` that tail-reads stdout logs and filters messages within the observation window
- Added `PeekMessageExtractor` class in `parsers.ts` supporting Codex, Claude, Gemini, and OpenCode natural-language extraction; Forge and unsupported agents return empty messages
- Added `parseGeminiOutput` and changed Gemini CLI output format from `json` to `stream-json` (NDJSON)
- Registered `peek` as an MCP tool (tool count: 6 → 7)
- Updated README.md and README.ja.md with `peek` API reference, CLI examples, and response schema

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [x] Manual testing (if applicable)

## Notes

- `peek` is intentionally a one-shot window (no `--follow` in v1); messages between separate `peek` calls may be missed
- Each PID keeps the first 50 messages observed; `truncated: true` if later messages were dropped
- Unknown PIDs return `not_found` per-process, not as a whole-call failure
