### PR TITLE
chore: CodexのCLIフラグを--dangerously-bypass-approvals-and-sandboxに更新

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 このMCPサーバーは、LLMがAI CLIツールと対話するためのツールを提供します。MCPクライアントと統合することで、LLMは以下のことが可能になります：
 
 - すべての権限確認をスキップしてClaude CLIを実行（`--dangerously-skip-permissions` を使用）
-- 自動承認モードでCodex CLIを実行（`--full-auto` を使用）
+- 承認とサンドボックスをバイパスしてCodex CLIを実行（`--dangerously-bypass-approvals-and-sandbox` を使用）
 - 自動承認モードでGemini CLIを実行（`-y` を使用）
 - Forge CLI を非対話モードで実行（`forge -C <workFolder> -p <prompt>` を使用）
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Did you notice that Cursor sometimes struggles with complex, multi-step edits or
 This MCP server provides tools that can be used by LLMs to interact with AI CLI tools. When integrated with MCP clients, it allows LLMs to:
 
 - Run Claude CLI with all permissions bypassed (using `--dangerously-skip-permissions`)
-- Execute Codex CLI with automatic approval mode (using `--full-auto`)
+- Execute Codex CLI with approvals and sandbox bypassed (using `--dangerously-bypass-approvals-and-sandbox`)
 - Execute Gemini CLI with automatic approval mode (using `-y`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -314,7 +314,8 @@ describe('cli-builder', () => {
         expect(cmd.agent).toBe('codex');
         expect(cmd.cliPath).toBe('/usr/bin/codex');
         expect(cmd.args).toContain('exec');
-        expect(cmd.args).toContain('--full-auto');
+        expect(cmd.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+        expect(cmd.args).not.toContain('--full-auto');
         expect(cmd.args).toContain('--json');
         expect(cmd.args).toContain('--model');
         expect(cmd.args).toContain('gpt-5.2-codex');

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -216,7 +216,7 @@ export function buildCliCommand(options: BuildCliCommandOptions): CliCommand {
       args.push('--model', resolvedModel);
     }
 
-    args.push('--skip-git-repo-check', '--full-auto', '--json', prompt);
+    args.push('--skip-git-repo-check', '--dangerously-bypass-approvals-and-sandbox', '--json', prompt);
   } else if (agent === 'gemini') {
     cliPath = options.cliPaths.gemini;
     args = ['-y', '--output-format', 'stream-json'];


### PR DESCRIPTION
## Summary

CodexのCLIフラグを `--full-auto` から `--dangerously-bypass-approvals-and-sandbox` に更新する。Codex CLIの新しいAPIに対応するための変更。

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Refactoring
- [x] docs: Documentation
- [x] test: Add or update tests
- [x] chore: Build, CI, dependencies, etc.

## Changes

- `src/cli-builder.ts`: Codex実行時のフラグを `--full-auto` から `--dangerously-bypass-approvals-and-sandbox` に変更
- `src/__tests__/cli-builder.test.ts`: 新しいフラグが含まれること、および古いフラグが含まれないことを検証するテストに更新
- `README.md` / `README.ja.md`: Codex CLIの説明を新しいフラグに合わせて更新

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

Codex CLIが `--full-auto` フラグを廃止し、`--dangerously-bypass-approvals-and-sandbox` に変更したことに対応する変更。
