### PR TITLE
feat: peekコマンドにtool_callイベントサポートを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -278,26 +278,29 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
 
 ### `peek`
 
-実行中の子エージェントを短時間だけ観測し、その `peek` 呼び出しの観測ウィンドウ内で ai-cli-mcp が受理した自然言語メッセージだけを返します。履歴APIではなく、欠落のないストリーミングでもなく、シェルの `stdout` / `stderr` tail でもありません。別々の `peek` 呼び出しの間に出たメッセージは取得できない場合があります。v1 では `--follow` はありません。
+実行中の子エージェントを短時間だけ観測し、その `peek` 呼び出しの観測ウィンドウ内で ai-cli-mcp が受理した構造化イベントを返します。デフォルトでは自然言語メッセージイベントだけを返し、`include_tool_calls` または `--include-tool-calls` を指定すると正規化された tool-call イベントも含めます。履歴APIではなく、欠落のないストリーミングでもなく、シェルの `stdout` / `stderr` tail でもありません。別々の `peek` 呼び出しの間に出たイベントは取得できない場合があります。v1 では `--follow` はありません。
 
 CLI v1:
 
 ```bash
 ai-cli peek 123 --time 10
 ai-cli peek 123 456 --time 10
+ai-cli peek 123 --time 10 --include-tool-calls
 ```
 
 **引数:**
 - `pids` (array of numbers, 必須): `run` が返したプロセスIDを 1..32 件指定します。重複したPIDはサーバー側で重複排除され、最初に出た順序が維持されます。未知または管理外のPIDは、呼び出し全体の失敗ではなく、プロセスごとに `not_found` として返されます。
 - `peek_time_sec` (number, 任意): 観測時間（秒）の正の整数です。デフォルトは10秒、最大60秒です。`0`、負数、小数は無効です。
+- `include_tool_calls` (boolean, 任意): `true` の場合、各プロセスの `events` 配列にメッセージイベントに加えて正規化された `tool_call` イベントを含めます。デフォルトは `false` です。
 
 **観測とフィルタリング:**
-- `peek_started_at` と `messages[].ts` は、ai-cli-mcp サーバー側の UTC RFC3339 タイムスタンプです。`peek_started_at` は検証とリスナー登録後に観測ウィンドウが始まった時刻、`messages[].ts` は ai-cli-mcp がメッセージを観測して受理した時刻です。
+- `peek_started_at` と `events[].ts` は、ai-cli-mcp サーバー側の UTC RFC3339 タイムスタンプです。`peek_started_at` は検証とリスナー登録後に観測ウィンドウが始まった時刻、`events[].ts` は ai-cli-mcp がイベントを観測して受理した時刻です。
 - 観測ウィンドウは `peek_time_sec` が経過するか、対象プロセスがすべて終端状態になった時点で終了します。
-- 観測開始前のメッセージは返しません。同じPIDへの同時 `peek` は可能で、それぞれ独立した観測ウィンドウを持つため、メッセージが重複して返ることがあります。
-- 返すのは認識済みの自然言語メッセージだけです。Codex の `agent_message` text、Claude assistant の text content、OpenCode の `type: "text"` かつ `part.type` が `"text"` のイベント、Gemini stream-json の `role` が `"assistant"` の `message` イベントを含めます。raw `stdout` / `stderr`、raw JSONL、reasoning、`tool_use`、`tool_result`、コマンドの `stdout` / `stderr`、command execution メタデータ、token usage、verbose メタデータは除外します。
-- 未知のイベント形状はデフォルトで拒否します。Forge など、自然言語抽出がまだ明示対応されていない管理対象エージェントは、実際のプロセス状態を返しつつ、`messages: []`、`truncated: false`、`error: null` にします。
-- 各PIDごとに、観測ウィンドウ内で最初に観測された50件までを保持します。それ以降のメッセージを捨てた場合は `truncated` が `true` になります。
+- 観測開始前のイベントは返しません。同じPIDへの同時 `peek` は可能で、それぞれ独立した観測ウィンドウを持つため、イベントが重複して返ることがあります。
+- メッセージイベントは、Codex の `agent_message` text、Claude assistant の text content、OpenCode の `type: "text"` かつ `part.type` が `"text"` のイベント、Gemini stream-json の `role` が `"assistant"` の `message` イベントから認識します。
+- tool call を含める場合、Codex の command/MCP call、Claude の tool use/result、Gemini の tool use/result、OpenCode の完了済み tool use event を正規化した `tool_call` イベントとして返します。tool summary は tool 名と入力メタデータだけから作る短い1行文字列です。raw `stdout` / `stderr`、raw JSONL、tool result output、コマンド出力、`result.response`、stats、token usage、verbose メタデータは除外します。
+- 未知のイベント形状はデフォルトで拒否します。Forge など、まだ明示対応されていない管理対象エージェントは、実際のプロセス状態を返しつつ、`events: []`、`truncated: false`、`error: null` にします。
+- 各PIDごとに、観測ウィンドウ内で最初に観測された50件までを保持します。それ以降のイベントを捨てた場合は `truncated` が `true` になります。
 - `status` は `running`、`completed`、`failed`、`not_found` のいずれかで、観測ウィンドウ終了時点の状態を表します。
 - `agent` は `claude`、`codex`、`gemini`、`forge`、`opencode`、将来追加される追跡済みエージェント文字列、または `null` です。`null` はプロセスが見つからない、またはエージェント種別を判断できない場合を表します。
 
@@ -312,8 +315,9 @@ ai-cli peek 123 456 --time 10
       "pid": 123,
       "agent": "codex",
       "status": "running",
-      "messages": [
-        { "ts": "2026-04-11T12:34:59.120Z", "text": "I'm checking the implementation." }
+      "events": [
+        { "kind": "message", "ts": "2026-04-11T12:34:59.120Z", "text": "I'm checking the implementation." },
+        { "kind": "tool_call", "ts": "2026-04-11T12:35:00.000Z", "phase": "started", "id": "item_0", "tool": "command_execution", "summary": "/bin/sh -c 'echo hi'" }
       ],
       "truncated": false,
       "error": null
@@ -322,7 +326,7 @@ ai-cli peek 123 456 --time 10
       "pid": 999,
       "agent": null,
       "status": "not_found",
-      "messages": [],
+      "events": [],
       "truncated": false,
       "error": "process not found"
     }

--- a/README.md
+++ b/README.md
@@ -275,26 +275,29 @@ By default, each returned result item uses the compact shape shared with `get_re
 
 ### `peek`
 
-Starts a one-shot short observation window for running child agents and returns only natural-language agent messages observed during that specific call. It is not a history API, not gapless streaming, and not shell stdout/stderr tailing. Separate `peek` calls may miss messages emitted between calls; `--follow` is intentionally not part of v1.
+Starts a one-shot short observation window for running child agents and returns structured events observed during that specific call. By default this includes only natural-language message events; pass `include_tool_calls` or `--include-tool-calls` to also include normalized tool-call events. It is not a history API, not gapless streaming, and not shell stdout/stderr tailing. Separate `peek` calls may miss events emitted between calls; `--follow` is intentionally not part of v1.
 
 CLI v1:
 
 ```bash
 ai-cli peek 123 --time 10
 ai-cli peek 123 456 --time 10
+ai-cli peek 123 --time 10 --include-tool-calls
 ```
 
 **Arguments:**
 - `pids` (array of numbers, required): 1..32 process IDs returned by `run`. Duplicate PIDs are deduplicated server-side, preserving first occurrence order. Unknown or unmanaged PIDs are returned per process as `not_found`, not as a whole-call failure.
 - `peek_time_sec` (number, optional): Positive integer observation length in seconds. Defaults to 10 and is capped at 60. `0`, negative values, and fractional values are invalid.
+- `include_tool_calls` (boolean, optional): When `true`, each process `events` array includes normalized `tool_call` events in addition to message events. Defaults to `false`.
 
 **Observation and filtering:**
-- `peek_started_at` and `messages[].ts` are ai-cli-mcp server-side UTC RFC3339 timestamps. `peek_started_at` is when the observation window starts after validation and listener registration; `messages[].ts` is when ai-cli-mcp observed and accepted the message.
+- `peek_started_at` and `events[].ts` are ai-cli-mcp server-side UTC RFC3339 timestamps. `peek_started_at` is when the observation window starts after validation and listener registration; `events[].ts` is when ai-cli-mcp observed and accepted the event.
 - The window ends when `peek_time_sec` elapses or all target processes reach a terminal state, whichever comes first.
-- Messages emitted before the window starts are not returned. Concurrent `peek` calls for the same PID are allowed; each has an independent window and may return overlapping messages.
-- Only recognized natural-language agent messages are returned: Codex `agent_message` text, Claude assistant text content, OpenCode `type: "text"` events where `part.type` is `"text"`, and Gemini stream-json `message` events where `role` is `"assistant"`. Raw stdout/stderr, raw JSONL, reasoning, `tool_use`, `tool_result`, command stdout/stderr, command execution metadata, token usage, and verbose metadata are excluded.
-- Unknown event shapes are denied by default. Managed agents without supported natural-language extraction, such as Forge until explicitly supported, return their real process status with `messages: []`, `truncated: false`, and `error: null`.
-- Each PID keeps the first 50 messages observed in the window. If later messages are dropped, `truncated` is `true`.
+- Events emitted before the window starts are not returned. Concurrent `peek` calls for the same PID are allowed; each has an independent window and may return overlapping events.
+- Message events are recognized from Codex `agent_message` text, Claude assistant text content, OpenCode `type: "text"` events where `part.type` is `"text"`, and Gemini stream-json `message` events where `role` is `"assistant"`.
+- When tool calls are included, `tool_call` events are normalized for Codex command/MCP calls, Claude tool use/results, Gemini tool use/results, and OpenCode completed tool use events. Tool summaries are bounded one-line strings derived from tool names and input metadata only. Raw stdout/stderr, raw JSONL, tool result output, command output, `result.response`, stats, token usage, and verbose metadata are excluded.
+- Unknown event shapes are denied by default. Managed agents without supported extraction, such as Forge until explicitly supported, return their real process status with `events: []`, `truncated: false`, and `error: null`.
+- Each PID keeps the first 50 events observed in the window. If later events are dropped, `truncated` is `true`.
 - `status` is one of `running`, `completed`, `failed`, or `not_found`, and reflects state when the observation window closes.
 - `agent` is `claude`, `codex`, `gemini`, `forge`, `opencode`, a future tracked string value, or `null` when the process is not found or the agent cannot be determined.
 
@@ -309,8 +312,9 @@ Example response:
       "pid": 123,
       "agent": "codex",
       "status": "running",
-      "messages": [
-        { "ts": "2026-04-11T12:34:59.120Z", "text": "I'm checking the implementation." }
+      "events": [
+        { "kind": "message", "ts": "2026-04-11T12:34:59.120Z", "text": "I'm checking the implementation." },
+        { "kind": "tool_call", "ts": "2026-04-11T12:35:00.000Z", "phase": "started", "id": "item_0", "tool": "command_execution", "summary": "/bin/sh -c 'echo hi'" }
       ],
       "truncated": false,
       "error": null
@@ -319,7 +323,7 @@ Example response:
       "pid": 999,
       "agent": null,
       "status": "not_found",
-      "messages": [],
+      "events": [],
       "truncated": false,
       "error": "process not found"
     }

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -210,7 +210,7 @@ describe('ai-cli app', () => {
     });
 
     const exitCode = await runCli(
-      ['peek', '123', '456', '123', '--time', '5'],
+      ['peek', '123', '456', '123', '--time', '5', '--include-tool-calls'],
       {
         stdout,
         stderr,
@@ -219,7 +219,7 @@ describe('ai-cli app', () => {
     );
 
     expect(exitCode).toBe(0);
-    expect(peekProcesses).toHaveBeenCalledWith([123, 456], 5);
+    expect(peekProcesses).toHaveBeenCalledWith([123, 456], 5, true);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('"peek_started_at"'));
     expect(stderr).not.toHaveBeenCalled();
   });
@@ -235,7 +235,7 @@ describe('ai-cli app', () => {
 
     const defaultExitCode = await runCli(['peek', '123'], { stdout, stderr, peekProcesses });
     expect(defaultExitCode).toBe(0);
-    expect(peekProcesses).toHaveBeenCalledWith([123], 10);
+    expect(peekProcesses).toHaveBeenCalledWith([123], 10, false);
 
     const followExitCode = await runCli(['peek', '123', '--follow'], { stdout, stderr, peekProcesses });
     expect(followExitCode).toBe(1);

--- a/src/__tests__/cli-process-service.test.ts
+++ b/src/__tests__/cli-process-service.test.ts
@@ -171,8 +171,9 @@ printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_
       pid: runResult.pid,
       agent: 'claude',
       status: 'completed',
-      messages: [
+      events: [
         {
+          kind: 'message',
           ts: expect.any(String),
           text: 'new cli message',
         },
@@ -184,7 +185,7 @@ printf '%s\n' '{"type":"user","message":{"content":[{"type":"tool_result","tool_
       pid: 999999,
       agent: null,
       status: 'not_found',
-      messages: [],
+      events: [],
       truncated: false,
       error: 'process not found',
     });

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -137,6 +137,7 @@ describe('MCP Contract Tests', () => {
     const peekTool = tools.find((tool: any) => tool.name === 'peek');
     expect(peekTool.inputSchema.required).toEqual(['pids']);
     expect(Object.keys(peekTool.inputSchema.properties).sort()).toEqual([
+      'include_tool_calls',
       'peek_time_sec',
       'pids',
     ]);

--- a/src/__tests__/parsers.test.ts
+++ b/src/__tests__/parsers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseCodexOutput, parseClaudeOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekMessageExtractor } from '../parsers.js';
+import { parseCodexOutput, parseClaudeOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor, PeekMessageExtractor } from '../parsers.js';
 
 describe('parseCodexOutput', () => {
   it('should parse basic Codex output with message and session_id', () => {
@@ -187,6 +187,160 @@ describe('PeekMessageExtractor', () => {
     const extractor = new PeekMessageExtractor('codex');
     expect(extractor.push('{"type":"item.completed","item":{"type":"agent_message","text":"pending"}}', ts)).toEqual([]);
     expect(extractor.flush(ts)).toEqual([{ ts, text: 'pending' }]);
+  });
+});
+
+describe('PeekEventExtractor', () => {
+  const ts = '2026-04-12T02:10:00.000Z';
+
+  it('emits only message events when include_tool_calls is false', () => {
+    const extractor = new PeekEventExtractor('codex', { includeToolCalls: false });
+    const output = [
+      '{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"echo secret","status":"in_progress"}}',
+      '{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"echo secret","aggregated_output":"secret output\\n","exit_code":0,"status":"completed"}}',
+      '{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"Visible Codex message"}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      { kind: 'message', ts, text: 'Visible Codex message' },
+    ]);
+  });
+
+  it('emits Codex command and MCP tool_call events without raw output when include_tool_calls is true', () => {
+    const extractor = new PeekEventExtractor('codex', { includeToolCalls: true });
+    const output = [
+      '{"type":"item.started","item":{"id":"cmd_0","type":"command_execution","command":"/bin/sh -c \\"echo secret\\"","status":"in_progress"}}',
+      '{"type":"item.completed","item":{"id":"cmd_0","type":"command_execution","command":"/bin/sh -c \\"echo secret\\"","aggregated_output":"secret output\\n","exit_code":0,"status":"completed"}}',
+      '{"type":"item.started","item":{"id":"mcp_0","type":"mcp_tool_call","server":"acm","tool":"list_processes","arguments":{},"status":"in_progress"}}',
+      '{"type":"item.completed","item":{"id":"mcp_0","type":"mcp_tool_call","server":"acm","tool":"list_processes","arguments":{},"result":{"content":[{"type":"text","text":"secret result"}]},"status":"completed"}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'started',
+        id: 'cmd_0',
+        tool: 'command_execution',
+        summary: '/bin/sh -c "echo secret"',
+      },
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'completed',
+        id: 'cmd_0',
+        tool: 'command_execution',
+        summary: '/bin/sh -c "echo secret"',
+        status: 'success',
+        exit_code: 0,
+      },
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'started',
+        id: 'mcp_0',
+        tool: 'list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+      },
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'completed',
+        id: 'mcp_0',
+        tool: 'list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+        status: 'success',
+      },
+    ]);
+  });
+
+  it('emits Claude MCP tool_call events paired by id', () => {
+    const extractor = new PeekEventExtractor('claude', { includeToolCalls: true });
+    const output = [
+      '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"mcp__acm__list_processes","input":{}}]}}',
+      '{"type":"user","message":{"content":[{"tool_use_id":"toolu_1","type":"tool_result","content":[{"type":"text","text":"secret result"}]}]}}',
+      '{"type":"assistant","message":{"content":[{"type":"text","text":"Done."}]}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'started',
+        id: 'toolu_1',
+        tool: 'mcp__acm__list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+      },
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'completed',
+        id: 'toolu_1',
+        tool: 'mcp__acm__list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+        status: 'success',
+      },
+      { kind: 'message', ts, text: 'Done.' },
+    ]);
+  });
+
+  it('emits Gemini MCP tool_call events and joined assistant message events', () => {
+    const extractor = new PeekEventExtractor('gemini', { includeToolCalls: true });
+    const output = [
+      '{"type":"tool_use","timestamp":"2026-04-12T02:56:29.992Z","tool_name":"mcp_acm_list_processes","tool_id":"mcp_1","parameters":{}}',
+      '{"type":"tool_result","timestamp":"2026-04-12T02:56:30.059Z","tool_id":"mcp_1","status":"success","output":"secret result"}',
+      '{"type":"message","timestamp":"2026-04-12T02:56:32.855Z","role":"assistant","content":"The tool ","delta":true}',
+      '{"type":"message","timestamp":"2026-04-12T02:56:32.902Z","role":"assistant","content":"succeeded.","delta":true}',
+      '{"type":"result","timestamp":"2026-04-12T02:56:32.954Z","status":"success","stats":{"tool_calls":1}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'started',
+        id: 'mcp_1',
+        tool: 'mcp_acm_list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+      },
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'completed',
+        id: 'mcp_1',
+        tool: 'mcp_acm_list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+        status: 'success',
+      },
+      { kind: 'message', ts, text: 'The tool succeeded.' },
+    ]);
+  });
+
+  it('emits OpenCode completed MCP tool_call events from tool_use state', () => {
+    const extractor = new PeekEventExtractor('opencode', { includeToolCalls: true });
+    const output = [
+      '{"type":"tool_use","timestamp":1775962663837,"sessionID":"ses-1","part":{"id":"part-1","type":"tool","tool":"acm_list_processes","callID":"call_1","state":{"status":"completed","input":{},"output":"secret result","metadata":{"truncated":false},"time":{"start":1775962663834,"end":1775962663837}}}}',
+    ].join('\n') + '\n';
+
+    expect(extractor.push(output, ts)).toEqual([
+      {
+        kind: 'tool_call',
+        ts,
+        phase: 'completed',
+        id: 'call_1',
+        tool: 'acm_list_processes',
+        server: 'acm',
+        summary: 'acm.list_processes',
+        status: 'success',
+        duration_ms: 3,
+      },
+    ]);
   });
 });
 

--- a/src/__tests__/peek.test.ts
+++ b/src/__tests__/peek.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { appendPeekMessages, validatePeekPids, validatePeekTimeSec, type PeekProcessResult } from '../peek.js';
+import { appendPeekEvents, validatePeekPids, validatePeekTimeSec, type PeekProcessResult } from '../peek.js';
 
 describe('peek helpers', () => {
   it('dedupes pids while preserving first occurrence order', () => {
@@ -17,27 +17,28 @@ describe('peek helpers', () => {
     expect(() => validatePeekTimeSec(61)).toThrow(/positive integer/);
   });
 
-  it('keeps the first 50 messages and marks truncation when later messages are dropped', () => {
+  it('keeps the first 50 events and marks truncation when later events are dropped', () => {
     const process: PeekProcessResult = {
       pid: 123,
       agent: 'codex',
       status: 'running',
-      messages: [],
+      events: [],
       truncated: false,
       error: null,
     };
 
-    appendPeekMessages(
+    appendPeekEvents(
       process,
       Array.from({ length: 55 }, (_, index) => ({
+        kind: 'message' as const,
         ts: '2026-04-11T12:34:56.789Z',
         text: `message ${index}`,
       })),
     );
 
-    expect(process.messages).toHaveLength(50);
-    expect(process.messages[0].text).toBe('message 0');
-    expect(process.messages[49].text).toBe('message 49');
+    expect(process.events).toHaveLength(50);
+    expect(process.events[0]).toMatchObject({ kind: 'message', text: 'message 0' });
+    expect(process.events[49]).toMatchObject({ kind: 'message', text: 'message 49' });
     expect(process.truncated).toBe(true);
   });
 });

--- a/src/__tests__/process-management.test.ts
+++ b/src/__tests__/process-management.test.ts
@@ -166,8 +166,9 @@ describe('Process Management Tests', () => {
         pid: 12345,
         agent: 'claude',
         status: 'completed',
-        messages: [
+        events: [
           {
+            kind: 'message',
             ts: expect.any(String),
             text: 'new message',
           },
@@ -179,7 +180,7 @@ describe('Process Management Tests', () => {
         pid: 99999,
         agent: null,
         status: 'not_found',
-        messages: [],
+        events: [],
         truncated: false,
         error: 'process not found',
       });
@@ -232,8 +233,9 @@ describe('Process Management Tests', () => {
         pid: 12346,
         agent: 'opencode',
         status: 'completed',
-        messages: [
+        events: [
           {
+            kind: 'message',
             ts: expect.any(String),
             text: 'OpenCode visible text',
           },
@@ -291,8 +293,9 @@ describe('Process Management Tests', () => {
         pid: 12347,
         agent: 'gemini',
         status: 'completed',
-        messages: [
+        events: [
           {
+            kind: 'message',
             ts: expect.any(String),
             text: 'Visible Gemini text',
           },
@@ -300,6 +303,85 @@ describe('Process Management Tests', () => {
         truncated: false,
         error: null,
       });
+    });
+
+    it('should include normalized tool_call events when requested', async () => {
+      const { handlers } = await setupServer();
+
+      const mockProcess = new EventEmitter() as any;
+      mockProcess.pid = 12348;
+      mockProcess.stdout = new EventEmitter();
+      mockProcess.stderr = new EventEmitter();
+      mockProcess.kill = vi.fn();
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      const callToolHandler = handlers.get('callTool')!;
+      await callToolHandler!({
+        params: {
+          name: 'run',
+          arguments: {
+            prompt: 'claude mcp peek prompt',
+            workFolder: '/tmp',
+            model: 'haiku',
+          }
+        }
+      });
+
+      const peekPromise = callToolHandler!({
+        params: {
+          name: 'peek',
+          arguments: {
+            pids: [12348],
+            peek_time_sec: 1,
+            include_tool_calls: true,
+          }
+        }
+      });
+
+      setTimeout(() => {
+        mockProcess.stdout.emit('data', '{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"mcp__acm__list_processes","input":{}}]}}\n');
+        mockProcess.stdout.emit('data', '{"type":"user","message":{"content":[{"tool_use_id":"toolu_1","type":"tool_result","content":[{"type":"text","text":"secret result"}]}]}}\n');
+        mockProcess.stdout.emit('data', '{"type":"assistant","message":{"content":[{"type":"text","text":"MCP succeeded."}]}}\n');
+        mockProcess.emit('close', 0);
+      }, 10);
+
+      const result = await peekPromise;
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.processes).toHaveLength(1);
+      expect(response.processes[0]).toMatchObject({
+        pid: 12348,
+        agent: 'claude',
+        status: 'completed',
+        events: [
+          {
+            kind: 'tool_call',
+            phase: 'started',
+            id: 'toolu_1',
+            tool: 'mcp__acm__list_processes',
+            server: 'acm',
+            summary: 'acm.list_processes',
+          },
+          {
+            kind: 'tool_call',
+            phase: 'completed',
+            id: 'toolu_1',
+            tool: 'mcp__acm__list_processes',
+            server: 'acm',
+            summary: 'acm.list_processes',
+            status: 'success',
+          },
+          {
+            kind: 'message',
+            ts: expect.any(String),
+            text: 'MCP succeeded.',
+          },
+        ],
+        truncated: false,
+        error: null,
+      });
+      expect(JSON.stringify(response)).not.toContain('secret result');
     });
 
     it('should handle process with model parameter', async () => {

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -9,7 +9,7 @@ export const CLI_HELP_TEXT = `Usage: ai-cli <command> [options]
 Commands:
   run       Start an AI CLI process in the background
   wait      Wait for one or more pids
-  peek      Observe new natural-language agent messages for a short window
+  peek      Observe new agent events for a short window
   ps        List tracked processes
   result    Get the current result for a pid
   kill      Terminate a tracked pid
@@ -62,12 +62,13 @@ Options:
 
 export const PEEK_HELP_TEXT = `Usage: ai-cli peek <pid...> [options]
 
-Observe new natural-language agent messages for a short one-shot window.
-In v1, message extraction is supported for Codex, Claude, OpenCode, and Gemini; Forge returns status with messages: [].
+Observe new natural-language agent messages, and optionally tool calls, for a short one-shot window.
+In v1, message extraction is supported for Codex, Claude, OpenCode, and Gemini; Forge returns status with events: [].
 This is not a history API, gapless streaming, or stdout/stderr tailing. No --follow mode is available in v1.
 
 Options:
   --time <seconds>             Observation window in seconds. Defaults to 10, maximum 60
+  --include-tool-calls         Include normalized tool_call events without raw tool output
   --help, -h                   Show this help message
 `;
 
@@ -131,7 +132,7 @@ interface CliDeps {
   listProcesses: () => Promise<any>;
   getProcessResult: (pid: number, verbose: boolean) => Promise<any>;
   waitForProcesses: (pids: number[], timeoutSeconds?: number, verbose?: boolean) => Promise<any>;
-  peekProcesses: (pids: number[], peekTimeSec?: number) => Promise<any>;
+  peekProcesses: (pids: number[], peekTimeSec?: number, includeToolCalls?: boolean) => Promise<any>;
   killProcess: (pid: number) => Promise<any>;
   cleanupProcesses: () => Promise<any>;
   getDoctorStatus: () => any;
@@ -154,7 +155,7 @@ const defaultDeps: CliDeps = {
   listProcesses: () => getCliProcessService().listProcesses(),
   getProcessResult: (pid, verbose) => getCliProcessService().getProcessResult(pid, verbose),
   waitForProcesses: (pids, timeoutSeconds, verbose) => getCliProcessService().waitForProcesses(pids, timeoutSeconds, verbose),
-  peekProcesses: (pids, peekTimeSec) => getCliProcessService().peekProcesses(pids, peekTimeSec),
+  peekProcesses: (pids, peekTimeSec, includeToolCalls) => getCliProcessService().peekProcesses(pids, peekTimeSec, includeToolCalls),
   killProcess: (pid) => getCliProcessService().killProcess(pid),
   cleanupProcesses: () => getCliProcessService().cleanupProcesses(),
   getDoctorStatus: () => getCliDoctorStatus(),
@@ -367,7 +368,7 @@ export async function runCli(argv: string[], deps: Partial<CliDeps> = {}): Promi
       return 1;
     }
 
-    writeJson(stdout, await peekProcesses(pids, peekTimeSec));
+    writeJson(stdout, await peekProcesses(pids, peekTimeSec, 'include-tool-calls' in flags || 'include_tool_calls' in flags));
     return 0;
   }
 

--- a/src/app/mcp.ts
+++ b/src/app/mcp.ts
@@ -233,7 +233,7 @@ ${getSupportedModelsDescription()}
         },
         {
           name: 'peek',
-          description: 'One-shot short observation window for running child agents. Returns only natural-language agent messages observed during this call; not a history API, not gapless streaming, and not stdout/stderr tailing. In v1, message extraction is supported for Codex, Claude, OpenCode, and Gemini; Forge returns status with messages: [].',
+          description: 'One-shot short observation window for running child agents. Returns only natural-language message events, and optionally normalized tool_call events, observed during this call; not a history API, not gapless streaming, and not stdout/stderr tailing. In v1, message extraction is supported for Codex, Claude, OpenCode, and Gemini; Forge returns status with events: []. Tool calls exclude raw tool output.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -245,6 +245,10 @@ ${getSupportedModelsDescription()}
               peek_time_sec: {
                 type: 'number',
                 description: 'Optional positive integer observation window in seconds. Defaults to 10; maximum is 60.',
+              },
+              include_tool_calls: {
+                type: 'boolean',
+                description: 'Optional: include normalized tool_call events without raw tool output. Defaults to false.',
               },
             },
             required: ['pids'],
@@ -384,16 +388,21 @@ ${getSupportedModelsDescription()}
   private async handlePeek(toolArguments: any): Promise<ServerResult> {
     let pids: number[];
     let peekTimeSec: number;
+    let includeToolCalls: boolean;
 
     try {
       pids = validatePeekPids(toolArguments.pids);
       peekTimeSec = validatePeekTimeSec(toolArguments.peek_time_sec);
+      if (toolArguments.include_tool_calls !== undefined && typeof toolArguments.include_tool_calls !== 'boolean') {
+        throw new Error('include_tool_calls must be a boolean when provided');
+      }
+      includeToolCalls = toolArguments.include_tool_calls === true;
     } catch (error: any) {
       throw new McpError(ErrorCode.InvalidParams, error.message);
     }
 
     try {
-      const response = await this.processService.peekProcesses(pids, peekTimeSec);
+      const response = await this.processService.peekProcesses(pids, peekTimeSec, includeToolCalls);
       return {
         content: [{
           type: 'text',

--- a/src/cli-process-service.ts
+++ b/src/cli-process-service.ts
@@ -19,10 +19,10 @@ import { join, basename, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
 import { findClaudeCli, findCodexCli, findForgeCli, findGeminiCli, findOpencodeCli } from './cli-utils.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekMessageExtractor } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import { buildProcessResult } from './process-result.js';
 import {
-  appendPeekMessages,
+  appendPeekEvents,
   buildNotFoundPeekProcess,
   observedDurationSec,
   validatePeekPids,
@@ -255,15 +255,15 @@ export class CliProcessService {
     }
   }
 
-  async peekProcesses(pids: number[], peekTimeSec = 10): Promise<PeekResponse> {
+  async peekProcesses(pids: number[], peekTimeSec = 10, includeToolCalls = false): Promise<PeekResponse> {
     const targetPids = validatePeekPids(pids);
     const targetPeekTimeSec = validatePeekTimeSec(peekTimeSec);
     const processes: PeekProcessResult[] = [];
     const observers: Array<{
       process: StoredProcess;
       result: PeekProcessResult;
-      stdoutExtractor: PeekMessageExtractor;
-      stderrExtractor: PeekMessageExtractor;
+      stdoutExtractor: PeekEventExtractor;
+      stderrExtractor: PeekEventExtractor;
       stdoutOffset: number;
       stderrOffset: number;
     }> = [];
@@ -281,7 +281,7 @@ export class CliProcessService {
         pid,
         agent: process.toolType,
         status: process.status,
-        messages: [],
+        events: [],
         truncated: false,
         error: null,
       };
@@ -289,8 +289,8 @@ export class CliProcessService {
       observers.push({
         process,
         result,
-        stdoutExtractor: new PeekMessageExtractor(process.toolType),
-        stderrExtractor: new PeekMessageExtractor(process.toolType),
+        stdoutExtractor: new PeekEventExtractor(process.toolType, { includeToolCalls }),
+        stderrExtractor: new PeekEventExtractor(process.toolType, { includeToolCalls }),
         stdoutOffset: this.fileSizeSafe(process.stdoutPath),
         stderrOffset: this.fileSizeSafe(process.stderrPath),
       });
@@ -307,11 +307,11 @@ export class CliProcessService {
       for (const observer of observers) {
         const stdoutRead = this.readTextFromOffset(observer.process.stdoutPath, observer.stdoutOffset);
         observer.stdoutOffset = stdoutRead.offset;
-        appendPeekMessages(observer.result, observer.stdoutExtractor.push(stdoutRead.text, observedAt));
+        appendPeekEvents(observer.result, observer.stdoutExtractor.push(stdoutRead.text, observedAt));
 
         const stderrRead = this.readTextFromOffset(observer.process.stderrPath, observer.stderrOffset);
         observer.stderrOffset = stderrRead.offset;
-        appendPeekMessages(observer.result, observer.stderrExtractor.push(stderrRead.text, observedAt));
+        appendPeekEvents(observer.result, observer.stderrExtractor.push(stderrRead.text, observedAt));
 
         observer.process = this.refreshStatus(this.readProcess(observer.process.pid));
         observer.result.status = observer.process.status;
@@ -335,8 +335,8 @@ export class CliProcessService {
     for (const observer of observers) {
       observer.process = this.refreshStatus(this.readProcess(observer.process.pid));
       observer.result.status = observer.process.status;
-      appendPeekMessages(observer.result, observer.stdoutExtractor.flush(flushTs));
-      appendPeekMessages(observer.result, observer.stderrExtractor.flush(flushTs));
+      appendPeekEvents(observer.result, observer.stdoutExtractor.flush(flushTs));
+      appendPeekEvents(observer.result, observer.stderrExtractor.flush(flushTs));
     }
 
     return {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -5,7 +5,46 @@ export interface PeekMessage {
   text: string;
 }
 
+export type PeekToolCallStatus = 'success' | 'failed' | 'cancelled' | 'unknown';
+
+export type PeekEvent =
+  | { kind: 'message'; ts: string; text: string }
+  | {
+      kind: 'tool_call';
+      ts: string;
+      phase: 'started' | 'completed';
+      tool: string;
+      summary: string;
+      id?: string;
+      status?: PeekToolCallStatus;
+      server?: string;
+      exit_code?: number;
+      duration_ms?: number;
+      summary_truncated?: boolean;
+    };
+
+type PeekToolCallEvent = Extract<PeekEvent, { kind: 'tool_call' }>;
+
 type PeekAgent = 'claude' | 'codex' | string | null;
+
+interface PeekEventExtractorOptions {
+  includeToolCalls?: boolean;
+}
+
+interface ToolSummary {
+  summary: string;
+  server?: string;
+  summary_truncated?: boolean;
+}
+
+interface ToolCallMemory {
+  tool: string;
+  server?: string;
+  summary: string;
+  summary_truncated?: boolean;
+}
+
+const PEEK_TOOL_SUMMARY_MAX_LENGTH = 200;
 
 function isGeminiAssistantMessageEvent(parsed: any): boolean {
   return parsed.type === 'message' && parsed.role === 'assistant' && typeof parsed.content === 'string';
@@ -25,37 +64,292 @@ function isGeminiStreamJsonEvent(parsed: any): boolean {
   return parsed && typeof parsed === 'object' && !Array.isArray(parsed) && GEMINI_STREAM_EVENT_TYPES.has(parsed.type);
 }
 
-function extractPeekMessagesFromParsedEvent(agent: PeekAgent, parsed: any, observedAt: string): PeekMessage[] {
+function oneLine(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function boundedSummary(value: string): { summary: string; summary_truncated?: boolean } {
+  const summary = oneLine(value);
+  if (summary.length <= PEEK_TOOL_SUMMARY_MAX_LENGTH) {
+    return { summary };
+  }
+
+  return {
+    summary: `${summary.slice(0, PEEK_TOOL_SUMMARY_MAX_LENGTH - 3)}...`,
+    summary_truncated: true,
+  };
+}
+
+function normalizeMcpToolName(tool: string, explicitServer?: string): ToolSummary | null {
+  if (explicitServer) {
+    return {
+      server: explicitServer,
+      ...boundedSummary(`${explicitServer}.${tool}`),
+    };
+  }
+
+  const mcpDouble = tool.match(/^mcp__([^_]+)__(.+)$/);
+  if (mcpDouble) {
+    return {
+      server: mcpDouble[1],
+      ...boundedSummary(`${mcpDouble[1]}.${mcpDouble[2]}`),
+    };
+  }
+
+  const mcpSingle = tool.match(/^mcp_([^_]+)_(.+)$/);
+  if (mcpSingle) {
+    return {
+      server: mcpSingle[1],
+      ...boundedSummary(`${mcpSingle[1]}.${mcpSingle[2]}`),
+    };
+  }
+
+  const acmShort = tool.match(/^acm_(.+)$/);
+  if (acmShort) {
+    return {
+      server: 'acm',
+      ...boundedSummary(`acm.${acmShort[1]}`),
+    };
+  }
+
+  return null;
+}
+
+function buildToolSummary(tool: string, options: { server?: string; command?: unknown } = {}): ToolSummary {
+  if (typeof options.command === 'string' && options.command.trim()) {
+    return boundedSummary(options.command);
+  }
+
+  const mcpSummary = normalizeMcpToolName(tool, options.server);
+  if (mcpSummary) {
+    return mcpSummary;
+  }
+
+  return boundedSummary(tool || 'tool_call');
+}
+
+function normalizeToolStatus(rawStatus: unknown, exitCode?: number, defaultStatus: PeekToolCallStatus = 'unknown'): PeekToolCallStatus {
+  if (typeof exitCode === 'number') {
+    return exitCode === 0 ? 'success' : 'failed';
+  }
+
+  const status = typeof rawStatus === 'string' ? rawStatus.toLowerCase() : '';
+  if (['success', 'succeeded', 'ok', 'completed'].includes(status)) {
+    return 'success';
+  }
+  if (['failed', 'failure', 'error', 'errored'].includes(status)) {
+    return 'failed';
+  }
+  if (['cancelled', 'canceled'].includes(status)) {
+    return 'cancelled';
+  }
+  return defaultStatus;
+}
+
+function createToolCallEvent(params: {
+  ts: string;
+  phase: 'started' | 'completed';
+  tool: string;
+  id?: string;
+  server?: string;
+  command?: unknown;
+  status?: unknown;
+  defaultStatus?: PeekToolCallStatus;
+  exit_code?: number;
+  duration_ms?: number;
+}): PeekToolCallEvent {
+  const tool = params.tool || 'tool_call';
+  const summary = buildToolSummary(tool, { server: params.server, command: params.command });
+  const event: PeekToolCallEvent = {
+    kind: 'tool_call',
+    ts: params.ts,
+    phase: params.phase,
+    tool,
+    summary: summary.summary,
+  };
+
+  if (params.id) {
+    event.id = params.id;
+  }
+  if (summary.server) {
+    event.server = summary.server;
+  } else if (params.server) {
+    event.server = params.server;
+  }
+  if (summary.summary_truncated) {
+    event.summary_truncated = true;
+  }
+  if (params.phase === 'completed') {
+    event.status = normalizeToolStatus(params.status, params.exit_code, params.defaultStatus);
+    if (typeof params.exit_code === 'number') {
+      event.exit_code = params.exit_code;
+    }
+    if (typeof params.duration_ms === 'number' && Number.isFinite(params.duration_ms)) {
+      event.duration_ms = params.duration_ms;
+    }
+  }
+
+  return event;
+}
+
+function rememberToolCall(event: PeekEvent, memory: Map<string, ToolCallMemory>): void {
+  if (event.kind !== 'tool_call' || !event.id) {
+    return;
+  }
+
+  memory.set(event.id, {
+    tool: event.tool,
+    server: event.server,
+    summary: event.summary,
+    summary_truncated: event.summary_truncated,
+  });
+}
+
+function createRememberedCompletion(params: {
+  ts: string;
+  id?: string;
+  memory: Map<string, ToolCallMemory>;
+  fallbackTool: string;
+  status?: unknown;
+  defaultStatus?: PeekToolCallStatus;
+}): PeekEvent {
+  const remembered = params.id ? params.memory.get(params.id) : undefined;
+  const event = createToolCallEvent({
+    ts: params.ts,
+    phase: 'completed',
+    id: params.id,
+    tool: remembered?.tool || params.fallbackTool,
+    server: remembered?.server,
+    status: params.status,
+    defaultStatus: params.defaultStatus,
+  });
+
+  if (remembered) {
+    event.summary = remembered.summary;
+    if (remembered.summary_truncated) {
+      event.summary_truncated = true;
+    }
+  }
+
+  return event;
+}
+
+function extractPeekEventsFromParsedEvent(agent: PeekAgent, parsed: any, observedAt: string, includeToolCalls: boolean, memory: Map<string, ToolCallMemory>): PeekEvent[] {
   if (agent === 'codex') {
     if (parsed.item?.type === 'agent_message' && typeof parsed.item.text === 'string' && parsed.item.text.trim()) {
-      return [{ ts: observedAt, text: parsed.item.text }];
+      return [{ kind: 'message', ts: observedAt, text: parsed.item.text }];
     }
     if (parsed.msg?.type === 'agent_message' && typeof parsed.msg.message === 'string' && parsed.msg.message.trim()) {
-      return [{ ts: observedAt, text: parsed.msg.message }];
+      return [{ kind: 'message', ts: observedAt, text: parsed.msg.message }];
+    }
+    if (includeToolCalls && (parsed.type === 'item.started' || parsed.type === 'item.completed')) {
+      const item = parsed.item;
+      if (item?.type === 'command_execution') {
+        const event = createToolCallEvent({
+          ts: observedAt,
+          phase: parsed.type === 'item.started' ? 'started' : 'completed',
+          id: item.id,
+          tool: 'command_execution',
+          command: item.command,
+          status: item.status || item.error,
+          exit_code: typeof item.exit_code === 'number' ? item.exit_code : undefined,
+          defaultStatus: parsed.type === 'item.completed' ? 'success' : 'unknown',
+        });
+        rememberToolCall(event, memory);
+        return [event];
+      }
+      if (item?.type === 'mcp_tool_call') {
+        const event = createToolCallEvent({
+          ts: observedAt,
+          phase: parsed.type === 'item.started' ? 'started' : 'completed',
+          id: item.id,
+          tool: item.tool || 'mcp_tool_call',
+          server: item.server,
+          status: item.status || item.error,
+          defaultStatus: parsed.type === 'item.completed' ? 'success' : 'unknown',
+        });
+        rememberToolCall(event, memory);
+        return [event];
+      }
     }
     return [];
   }
 
-  if (agent === 'claude' && parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
-    return parsed.message.content
-      .filter((content: any) => content?.type === 'text' && typeof content.text === 'string' && content.text.trim())
-      .map((content: any) => ({ ts: observedAt, text: content.text }));
+  if (agent === 'claude') {
+    if (parsed.type === 'assistant' && Array.isArray(parsed.message?.content)) {
+      const events: PeekEvent[] = [];
+      for (const content of parsed.message.content) {
+        if (content?.type === 'text' && typeof content.text === 'string' && content.text.trim()) {
+          events.push({ kind: 'message', ts: observedAt, text: content.text });
+        } else if (includeToolCalls && content?.type === 'tool_use') {
+          const event = createToolCallEvent({
+            ts: observedAt,
+            phase: 'started',
+            id: content.id,
+            tool: content.name || 'tool_use',
+            command: content.input?.command,
+          });
+          rememberToolCall(event, memory);
+          events.push(event);
+        }
+      }
+      return events;
+    }
+    if (includeToolCalls && parsed.type === 'user' && Array.isArray(parsed.message?.content)) {
+      const events: PeekEvent[] = [];
+      for (const content of parsed.message.content) {
+        if (content?.type === 'tool_result') {
+          events.push(createRememberedCompletion({
+            ts: observedAt,
+            id: content.tool_use_id,
+            memory,
+            fallbackTool: 'tool_result',
+            status: content.is_error === true ? 'failed' : undefined,
+            defaultStatus: content.is_error === true ? 'failed' : 'success',
+          }));
+        }
+      }
+      return events;
+    }
+    return [];
   }
 
   if (agent === 'opencode' && parsed.type === 'text' && parsed.part?.type === 'text' && typeof parsed.part.text === 'string' && parsed.part.text.trim()) {
-    return [{ ts: observedAt, text: parsed.part.text }];
+    return [{ kind: 'message', ts: observedAt, text: parsed.part.text }];
+  }
+
+  if (agent === 'opencode' && includeToolCalls && parsed.type === 'tool_use' && parsed.part?.type === 'tool') {
+    const state = parsed.part.state || {};
+    const start = state.time?.start;
+    const end = state.time?.end;
+    const event = createToolCallEvent({
+      ts: observedAt,
+      phase: state.status === 'running' || state.status === 'pending' ? 'started' : 'completed',
+      id: parsed.part.callID,
+      tool: parsed.part.tool || 'tool_use',
+      command: state.input?.command,
+      status: state.status,
+      defaultStatus: state.status === 'completed' ? 'success' : 'unknown',
+      duration_ms: typeof start === 'number' && typeof end === 'number' ? end - start : undefined,
+    });
+    rememberToolCall(event, memory);
+    return [event];
   }
 
   return [];
 }
 
-export class PeekMessageExtractor {
+export class PeekEventExtractor {
   private pending = '';
   private geminiAssistantBuffer = '';
+  private readonly includeToolCalls: boolean;
+  private readonly toolMemory = new Map<string, ToolCallMemory>();
 
-  constructor(private readonly agent: PeekAgent) {}
+  constructor(private readonly agent: PeekAgent, options: PeekEventExtractorOptions = {}) {
+    this.includeToolCalls = options.includeToolCalls === true;
+  }
 
-  push(chunk: string, observedAt = new Date().toISOString()): PeekMessage[] {
+  push(chunk: string, observedAt = new Date().toISOString()): PeekEvent[] {
     if (!chunk) {
       return [];
     }
@@ -65,21 +359,21 @@ export class PeekMessageExtractor {
     return this.extractLines(lines, observedAt);
   }
 
-  flush(observedAt = new Date().toISOString()): PeekMessage[] {
-    const messages: PeekMessage[] = [];
+  flush(observedAt = new Date().toISOString()): PeekEvent[] {
+    const events: PeekEvent[] = [];
 
     if (this.pending) {
       const line = this.pending;
       this.pending = '';
-      messages.push(...this.extractLines([line], observedAt));
+      events.push(...this.extractLines([line], observedAt));
     }
 
-    messages.push(...this.flushGeminiAssistantBuffer(observedAt));
-    return messages;
+    events.push(...this.flushGeminiAssistantBuffer(observedAt));
+    return events;
   }
 
-  private extractLines(lines: string[], observedAt: string): PeekMessage[] {
-    const messages: PeekMessage[] = [];
+  private extractLines(lines: string[], observedAt: string): PeekEvent[] {
+    const events: PeekEvent[] = [];
 
     for (const line of lines) {
       if (!line.trim()) {
@@ -87,30 +381,58 @@ export class PeekMessageExtractor {
       }
 
       try {
-        messages.push(...this.extractParsedEvent(JSON.parse(line), observedAt));
+        events.push(...this.extractParsedEvent(JSON.parse(line), observedAt));
       } catch {
         debugLog(`[Debug] Skipping invalid peek JSON line: ${line}`);
-        messages.push(...this.flushGeminiAssistantBuffer(observedAt));
+        events.push(...this.flushGeminiAssistantBuffer(observedAt));
       }
     }
 
-    return messages;
+    return events;
   }
 
-  private extractParsedEvent(parsed: any, observedAt: string): PeekMessage[] {
-    if (this.agent !== 'gemini') {
-      return extractPeekMessagesFromParsedEvent(this.agent, parsed, observedAt);
+  private extractParsedEvent(parsed: any, observedAt: string): PeekEvent[] {
+    if (this.agent === 'gemini') {
+      const events = this.extractGeminiParsedEvent(parsed, observedAt);
+      return events;
     }
 
+    return extractPeekEventsFromParsedEvent(this.agent, parsed, observedAt, this.includeToolCalls, this.toolMemory);
+  }
+
+  private extractGeminiParsedEvent(parsed: any, observedAt: string): PeekEvent[] {
     if (isGeminiAssistantMessageEvent(parsed)) {
       this.geminiAssistantBuffer += parsed.content;
       return [];
     }
 
-    return this.flushGeminiAssistantBuffer(observedAt);
+    const events = this.flushGeminiAssistantBuffer(observedAt);
+
+    if (this.includeToolCalls && parsed.type === 'tool_use') {
+      const event = createToolCallEvent({
+        ts: observedAt,
+        phase: 'started',
+        id: parsed.tool_id,
+        tool: parsed.tool_name || parsed.name || 'tool_use',
+        command: parsed.parameters?.command,
+      });
+      rememberToolCall(event, this.toolMemory);
+      events.push(event);
+    } else if (this.includeToolCalls && parsed.type === 'tool_result') {
+      events.push(createRememberedCompletion({
+        ts: observedAt,
+        id: parsed.tool_id,
+        memory: this.toolMemory,
+        fallbackTool: parsed.tool_name || parsed.name || 'tool_result',
+        status: parsed.status,
+        defaultStatus: 'unknown',
+      }));
+    }
+
+    return events;
   }
 
-  private flushGeminiAssistantBuffer(observedAt: string): PeekMessage[] {
+  private flushGeminiAssistantBuffer(observedAt: string): PeekEvent[] {
     if (this.agent !== 'gemini' || !this.geminiAssistantBuffer) {
       return [];
     }
@@ -122,7 +444,29 @@ export class PeekMessageExtractor {
       return [];
     }
 
-    return [{ ts: observedAt, text }];
+    return [{ kind: 'message', ts: observedAt, text }];
+  }
+}
+
+export class PeekMessageExtractor {
+  private readonly extractor: PeekEventExtractor;
+
+  constructor(agent: PeekAgent) {
+    this.extractor = new PeekEventExtractor(agent, { includeToolCalls: false });
+  }
+
+  push(chunk: string, observedAt = new Date().toISOString()): PeekMessage[] {
+    return this.toMessages(this.extractor.push(chunk, observedAt));
+  }
+
+  flush(observedAt = new Date().toISOString()): PeekMessage[] {
+    return this.toMessages(this.extractor.flush(observedAt));
+  }
+
+  private toMessages(events: PeekEvent[]): PeekMessage[] {
+    return events
+      .filter((event): event is Extract<PeekEvent, { kind: 'message' }> => event.kind === 'message')
+      .map((event) => ({ ts: event.ts, text: event.text }));
   }
 }
 

--- a/src/peek.ts
+++ b/src/peek.ts
@@ -1,4 +1,4 @@
-import type { PeekMessage } from './parsers.js';
+import type { PeekEvent, PeekMessage } from './parsers.js';
 import type { AgentType, ProcessStatus } from './process-service.js';
 
 export const DEFAULT_PEEK_TIME_SEC = 10;
@@ -13,7 +13,7 @@ export interface PeekProcessResult {
   pid: number;
   agent: PeekAgent;
   status: PeekStatus;
-  messages: PeekMessage[];
+  events: PeekEvent[];
   truncated: boolean;
   error: string | null;
 }
@@ -67,20 +67,27 @@ export function buildNotFoundPeekProcess(pid: number): PeekProcessResult {
     pid,
     agent: null,
     status: 'not_found',
-    messages: [],
+    events: [],
     truncated: false,
     error: 'process not found',
   };
 }
 
-export function appendPeekMessages(target: PeekProcessResult, messages: PeekMessage[]): void {
-  for (const message of messages) {
-    if (target.messages.length < PEEK_MESSAGE_CAP) {
-      target.messages.push(message);
+export function appendPeekEvents(target: PeekProcessResult, events: PeekEvent[]): void {
+  for (const event of events) {
+    if (target.events.length < PEEK_MESSAGE_CAP) {
+      target.events.push(event);
     } else {
       target.truncated = true;
     }
   }
+}
+
+export function appendPeekMessages(target: PeekProcessResult, messages: PeekMessage[]): void {
+  appendPeekEvents(
+    target,
+    messages.map((message) => ({ kind: 'message' as const, ...message })),
+  );
 }
 
 export function observedDurationSec(startedAtMs: number, endedAtMs = Date.now()): number {

--- a/src/process-service.ts
+++ b/src/process-service.ts
@@ -1,8 +1,8 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { buildCliCommand, type BuildCliCommandOptions } from './cli-builder.js';
-import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekMessageExtractor } from './parsers.js';
+import { parseClaudeOutput, parseCodexOutput, parseForgeOutput, parseGeminiOutput, parseOpenCodeOutput, PeekEventExtractor } from './parsers.js';
 import {
-  appendPeekMessages,
+  appendPeekEvents,
   buildNotFoundPeekProcess,
   observedDurationSec,
   validatePeekPids,
@@ -226,15 +226,15 @@ export class ProcessService {
     }
   }
 
-  async peekProcesses(pids: number[], peekTimeSec = 10): Promise<PeekResponse> {
+  async peekProcesses(pids: number[], peekTimeSec = 10, includeToolCalls = false): Promise<PeekResponse> {
     const targetPids = validatePeekPids(pids);
     const targetPeekTimeSec = validatePeekTimeSec(peekTimeSec);
     const processes: PeekProcessResult[] = [];
     const observers: Array<{
       entry: TrackedProcess;
       result: PeekProcessResult;
-      stdoutExtractor: PeekMessageExtractor;
-      stderrExtractor: PeekMessageExtractor;
+      stdoutExtractor: PeekEventExtractor;
+      stderrExtractor: PeekEventExtractor;
       onStdout: (data: Buffer | string) => void;
       onStderr: (data: Buffer | string) => void;
     }> = [];
@@ -250,19 +250,19 @@ export class ProcessService {
         pid,
         agent: entry.toolType,
         status: entry.status,
-        messages: [],
+        events: [],
         truncated: false,
         error: null,
       };
       processes.push(result);
 
-      const stdoutExtractor = new PeekMessageExtractor(entry.toolType);
-      const stderrExtractor = new PeekMessageExtractor(entry.toolType);
+      const stdoutExtractor = new PeekEventExtractor(entry.toolType, { includeToolCalls });
+      const stderrExtractor = new PeekEventExtractor(entry.toolType, { includeToolCalls });
       const onStdout = (data: Buffer | string) => {
-        appendPeekMessages(result, stdoutExtractor.push(data.toString(), new Date().toISOString()));
+        appendPeekEvents(result, stdoutExtractor.push(data.toString(), new Date().toISOString()));
       };
       const onStderr = (data: Buffer | string) => {
-        appendPeekMessages(result, stderrExtractor.push(data.toString(), new Date().toISOString()));
+        appendPeekEvents(result, stderrExtractor.push(data.toString(), new Date().toISOString()));
       };
 
       if (entry.status === 'running') {
@@ -294,8 +294,8 @@ export class ProcessService {
       for (const observer of observers) {
         observer.entry.process.stdout?.off('data', observer.onStdout);
         observer.entry.process.stderr?.off('data', observer.onStderr);
-        appendPeekMessages(observer.result, observer.stdoutExtractor.flush(flushTs));
-        appendPeekMessages(observer.result, observer.stderrExtractor.flush(flushTs));
+        appendPeekEvents(observer.result, observer.stdoutExtractor.flush(flushTs));
+        appendPeekEvents(observer.result, observer.stderrExtractor.flush(flushTs));
         observer.result.status = observer.entry.status;
       }
     }


### PR DESCRIPTION
## Summary

`peek` コマンドのレスポンス構造を `messages` から `events` に拡張し、自然言語メッセージに加えて正規化された `tool_call` イベントもサポートします。

## Type of Change

- [x] feat: New feature

## Changes

- `peek` レスポンスの `messages` フィールドを `events` に変更し、各イベントに `kind` フィールド（`"message"` または `"tool_call"`）を追加
- MCP スキーマおよび CLI に `include_tool_calls` / `--include-tool-calls` オプションを追加
- `PeekMessageExtractor` を `PeekEventExtractor` に置き換え、tool_call イベント抽出ロジックを実装
  - Codex: `command_execution` / `mcp_tool_call` の `item.started` / `item.completed` イベント対応
  - Claude: `tool_use` / `tool_result` ペアを id でマッチングして正規化
  - Gemini: `tool_use` / `tool_result` イベントを正規化
  - OpenCode: 完了済み `tool_use` イベントを正規化
- MCP ツール名 (`mcp__server__tool`, `mcp_server_tool`, `acm_tool` 形式) を `server.tool` 形式のサマリーに正規化する `normalizeMcpToolName` を実装
- tool サマリーを 200 文字以内に切り詰める `boundedSummary` を実装（機密 raw output の漏れを防止）
- `appendPeekMessages` を `appendPeekEvents` にリネーム
- README.md / README.ja.md のドキュメントを更新
- 各テストファイルを新しいイベント構造に対応して更新

## Test Plan

- [x] `npm run test:unit` passes
- [x] `npm run build` passes
- [ ] Manual testing (if applicable)

## Notes

<!-- Any additional context for reviewers -->
- raw tool output（`aggregated_output`, `result.response`, `stats` 等）は意図的に除外し、機密情報の漏洩を防いでいます
- `include_tool_calls` はデフォルト `false` のため、既存の呼び出し側への後方互換性が維持されます
- `messages: []` → `events: []` はブレーキングチェンジのため、呼び出し側の更新が必要です
