### PR TITLE
fix: shorten mcp registry description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ai-cli-mcp",
   "version": "2.19.0",
   "mcpName": "io.github.mkXultra/ai-cli-mcp",
-  "description": "MCP server for AI CLI tools (Claude, Codex, Gemini, Forge, and OpenCode) with background process management",
+  "description": "Run Claude, Codex, Gemini, Forge, and OpenCode CLIs through MCP with background jobs",
   "author": "mkXultra",
   "license": "MIT",
   "main": "dist/server.js",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mkXultra/ai-cli-mcp",
-  "description": "MCP server for AI CLI tools (Claude, Codex, Gemini, Forge, and OpenCode) with background process management",
+  "description": "Run Claude, Codex, Gemini, Forge, and OpenCode CLIs through MCP with background jobs",
   "repository": {
     "url": "https://github.com/mkXultra/ai-cli-mcp",
     "source": "github"

--- a/src/__tests__/package-smoke.test.ts
+++ b/src/__tests__/package-smoke.test.ts
@@ -88,6 +88,8 @@ describe('npm package smoke', () => {
     const serverJson = JSON.parse(readFileSync('server.json', 'utf8'));
 
     expect(serverJson.name).toBe(packageJson.mcpName);
+    expect(serverJson.description).toBe(packageJson.description);
+    expect(serverJson.description.length).toBeLessThanOrEqual(100);
     expect(serverJson.version).toBe(packageJson.version);
     expect(serverJson.packages).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- shorten package and MCP registry descriptions to satisfy the registry 100-character limit
- keep package.json and server.json descriptions aligned
- add package smoke coverage for the server.json description limit

## Verification
- npm run test:package
- pre-commit unit tests: 16 files, 263 tests passed