### PR TITLE
feat: Codex モデルカタログを整理し gpt-5.5 をサポート

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
-    - Codex (`codex` は Codex CLI 側の設定済みデフォルトモデル、加えて gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
+    - Codex (`codex` は Codex CLI 側の設定済みデフォルトモデル、加えて gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
     - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
     - Forge (`forge`)
     - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
@@ -259,9 +259,9 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
 - `prompt_file` (string, 任意): プロンプトを含むファイルへのパス。`prompt` または `prompt_file` のいずれかが必須です。絶対パス、または `workFolder` からの相対パスが指定可能です。
 - `workFolder` (string, 必須): CLIを実行する作業ディレクトリ。絶対パスである必要があります。
 - **モデル (Models):**
-    - **Ultra エイリアス:** `claude-ultra` (自動的に max effort に設定), `codex-ultra` (自動的に xhigh reasoning に設定), `gemini-ultra`
+    - **Ultra エイリアス:** `claude-ultra` (自動的に max effort に設定), `codex-ultra` (`gpt-5.5`、自動的に xhigh reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-    - Codex: `codex`（Codex CLI 側の設定済みデフォルトモデル）および `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
+    - Codex: `codex`（Codex CLI 側の設定済みデフォルトモデル）および `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
     - Forge: `forge`
     - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,7 +24,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 - OpenCode を非対話 JSON モードで実行（`opencode run --format json --dir <workFolder> <prompt>` を使用）
 - 複数のAIモデルのサポート：
     - Claude (sonnet, sonnet[1m], opus, opusplan, haiku)
-    - Codex (`codex` は Codex CLI 側の設定済みデフォルトモデル、加えて gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, など)
+    - Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2)
     - Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview)
     - Forge (`forge`)
     - OpenCode (`opencode` と `oc-<provider/model>` ラッパー。例: `oc-openai/gpt-5.4`)
@@ -37,7 +37,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 
 > 以下の3つのタスクをacm mcp runでエージェントを起動して：
 > 1. `sonnet` で `src/backend` のコードをリファクタリング
-> 2. `gpt-5.2-codex` で `src/frontend` のユニットテストを作成
+> 2. `gpt-5.3-codex` で `src/frontend` のユニットテストを作成
 > 3. `gemini-2.5-pro` で `docs/` のドキュメントを更新
 >
 > 実行中はあなたはTODOリストを更新する作業を行ってください。それが終わったら `wait` ツールを使ってすべての完了を待機し、結果をまとめて報告してください。
@@ -50,7 +50,7 @@ Cursorなどのエディタが、複雑な手順を伴う編集や操作に苦�
 > 2. `wait` ツールでこの処理の完了を待ち、結果から `session_id` を取得してください。
 > 3. その `session_id` を使い、以下の2つのタスクを `acm mcp run` で並行して実行してください：
 >    - `sonnet` で `src/utils` のリファクタリング案を作成
->    - `gpt-5.2-codex` で `README.md` にアーキテクチャの解説を追記
+>    - `gpt-5.3-codex` で `README.md` にアーキテクチャの解説を追記
 > 4. 最後に再び `wait` して、両方の結果をまとめてください。
 
 [![セッション再開デモ](docs/assets/demo-resume-jp.gif)](https://github.com/mkXultra/ai-cli-mcp/releases/download/v2.11.0/demo-resume-jp.mp4)
@@ -192,7 +192,7 @@ macOSでは、これらのツールを初めて実行する際にフォルダへ
 ```bash
 ai-cli doctor
 ai-cli models
-ai-cli run --cwd "$PWD" --model codex --prompt "Codex CLI のデフォルトモデルで実行"
+ai-cli run --cwd "$PWD" --model gpt-5.4 --prompt "デフォルトの Codex モデルで実行"
 ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
 ai-cli run --cwd "$PWD" --model opencode --session-id ses_existing --prompt "この OpenCode セッションを継続して"
 ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "明示的な OpenCode モデルで実行"
@@ -215,7 +215,7 @@ OpenCode のモデル指定は次の 2 つを受け付けます。
 
 `ai-cli models` は OpenCode を機械可読に `opencode: ["opencode"]` と `dynamicModelBackends.opencode` で公開します。実際に利用可能なバックエンドネイティブなモデル一覧は `opencode models` で確認してください。
 
-Codex のモデル指定では、`codex` を使うと Codex CLI 側の設定済みデフォルトモデルを使用します。Codex CLI がアカウント種別によって明示的な `gpt-*` モデル指定を受け付けない場合に有用です。
+Codex のモデル指定では、公開デフォルトモデルとして `gpt-5.4` を使用します。
 
 `doctor` は CLI バイナリの利用可否と path 解決だけを確認します。JSON 出力には `checks` ブロックが含まれ、ログイン状態と利用規約同意は未確認として示されます。
 
@@ -261,7 +261,7 @@ Claude CLI、Codex CLI、Gemini CLI、Forge CLI、または OpenCode を使用�
 - **モデル (Models):**
     - **Ultra エイリアス:** `claude-ultra` (自動的に max effort に設定), `codex-ultra` (`gpt-5.5`、自動的に xhigh reasoning に設定), `gemini-ultra`
     - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-    - Codex: `codex`（Codex CLI 側の設定済みデフォルトモデル）および `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
+    - Codex: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
     - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
     - Forge: `forge`
     - OpenCode: `opencode`（設定済みのデフォルトモデル）および `oc-openai/gpt-5.4` のような明示ラッパー

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Execute Gemini CLI with automatic approval mode (using `-y`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (`codex` for the CLI's configured default model, plus gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (`codex` for the CLI's configured default model, plus gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -256,9 +256,9 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCod
 - `prompt_file` (string, optional): Path to a file containing the prompt. Either `prompt` or `prompt_file` is required. Can be absolute path or relative to `workFolder`.
 - `workFolder` (string, required): The working directory for the CLI execution. Must be an absolute path.
 **Models:**
-- **Ultra Aliases:** `claude-ultra` (defaults to max effort), `codex-ultra` (defaults to xhigh reasoning), `gemini-ultra`
+- **Ultra Aliases:** `claude-ultra` (defaults to max effort), `codex-ultra` (`gpt-5.5`, defaults to xhigh reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-- Codex: `codex` for the CLI's configured default model, plus `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5`
+- Codex: `codex` for the CLI's configured default model, plus `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 - Forge: `forge`
 - OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This MCP server provides tools that can be used by LLMs to interact with AI CLI 
 - Execute Gemini CLI with automatic approval mode (using `-y`)
 - Execute Forge CLI in non-interactive mode (using `forge -C <workFolder> -p <prompt>`)
 - Execute OpenCode in non-interactive JSON mode (using `opencode run --format json --dir <workFolder> <prompt>`)
-- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (`codex` for the CLI's configured default model, plus gpt-5.5, gpt-5.4, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2, gpt-5.1, gpt-5.1-codex, gpt-5-codex, gpt-5-codex-mini, gpt-5), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
+- Support multiple AI models: Claude (sonnet, sonnet[1m], opus, opusplan, haiku), Codex (gpt-5.4, gpt-5.5, gpt-5.4-mini, gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5.2), Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview), Forge (`forge`), and OpenCode (`opencode` plus explicit `oc-<provider/model>` wrappers such as `oc-openai/gpt-5.4`)
 - Manage background processes with PID tracking
 - Parse and return structured outputs from both tools
 
@@ -34,7 +34,7 @@ You can instruct your main agent to run multiple tasks in parallel like this:
 
 > Launch agents for the following 3 tasks using acm mcp run:
 > 1. Refactor `src/backend` code using `sonnet`
-> 2. Create unit tests for `src/frontend` using `gpt-5.2-codex`
+> 2. Create unit tests for `src/frontend` using `gpt-5.3-codex`
 > 3. Update docs in `docs/` using `gemini-2.5-pro`
 >
 > While they run, please update the TODO list. Once done, use the `wait` tool to wait for all completions and report the results together.
@@ -47,7 +47,7 @@ You can reuse heavy context (like large codebases) using session IDs to save cos
 > 2. Use the `wait` tool to wait for completion and retrieve the `session_id` from the result.
 > 3. Using that `session_id`, run the following two tasks in parallel with `acm mcp run`:
 >    - Create refactoring proposals for `src/utils` using `sonnet`
->    - Add architecture documentation to `README.md` using `gpt-5.2-codex`
+>    - Add architecture documentation to `README.md` using `gpt-5.3-codex`
 > 4. Finally, `wait` again to combine both results.
 
 [![Session Resume Demo](docs/assets/demo-resume.gif)](https://github.com/mkXultra/ai-cli-mcp/releases/download/v2.11.0/demo-resume.mp4)
@@ -189,7 +189,7 @@ Example flow:
 ```bash
 ai-cli doctor
 ai-cli models
-ai-cli run --cwd "$PWD" --model codex --prompt "use the Codex CLI default model"
+ai-cli run --cwd "$PWD" --model gpt-5.4 --prompt "use the default Codex model"
 ai-cli run --cwd "$PWD" --model codex-ultra --prompt "fix failing tests"
 ai-cli run --cwd "$PWD" --model opencode --session-id ses_existing --prompt "continue this OpenCode session"
 ai-cli run --cwd "$PWD" --model oc-openai/gpt-5.4 --prompt "run with an explicit OpenCode backend model"
@@ -212,7 +212,7 @@ OpenCode model selection accepts either:
 
 `ai-cli models` exposes OpenCode machine-readably via `opencode: ["opencode"]` plus `dynamicModelBackends.opencode`, which points users to `opencode models` for backend-native discovery.
 
-Codex model selection accepts `codex` to use the Codex CLI's configured default model. This is useful for account types where explicit `gpt-*` model overrides are not accepted by the Codex CLI.
+Codex model selection uses `gpt-5.4` as the default advertised model.
 
 `doctor` checks only binary availability and path resolution. Its JSON output includes a `checks` block that marks login state and terms acceptance as unchecked.
 
@@ -258,7 +258,7 @@ Executes a prompt using Claude CLI, Codex CLI, Gemini CLI, Forge CLI, or OpenCod
 **Models:**
 - **Ultra Aliases:** `claude-ultra` (defaults to max effort), `codex-ultra` (`gpt-5.5`, defaults to xhigh reasoning), `gemini-ultra`
 - Claude: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-- Codex: `codex` for the CLI's configured default model, plus `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
+- Codex: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
 - Gemini: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 - Forge: `forge`
 - OpenCode: `opencode` for the configured default backend model, plus explicit wrappers like `oc-openai/gpt-5.4`

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -122,7 +122,7 @@ src/
 
 ```
 claude-ultra  → opus (+ reasoning_effort: max)
-codex-ultra   → gpt-5.4 (+ reasoning_effort: xhigh)
+codex-ultra   → gpt-5.5 (+ reasoning_effort: xhigh)
 gemini-ultra  → gemini-3.1-pro-preview
 ```
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -26,7 +26,7 @@ Claude Code や Codex CLI は対話的に使うことを前提としており、
 MCP Client (Cursor, Claude Code, etc.)
   │
   ├─ run(prompt, model="opus")     → PID 1234 (即座に返却)
-  ├─ run(prompt, model="gpt-5.2-codex")  → PID 1235
+  ├─ run(prompt, model="gpt-5.3-codex")  → PID 1235
   ├─ run(prompt, model="gemini-2.5-pro") → PID 1236
   │
   ├─ list_processes()  → 実行状況一覧

--- a/docs/development.md
+++ b/docs/development.md
@@ -102,13 +102,13 @@ CLI プロセスをフォアグラウンドで起動し、**生の stdout をそ
 npm run -s cli.run -- --model sonnet --workFolder /tmp --prompt "hello"
 
 # prompt file 指定
-npm run -s cli.run -- --model gpt-5.2-codex --workFolder /path/to/project --prompt_file prompt.txt
+npm run -s cli.run -- --model gpt-5.3-codex --workFolder /path/to/project --prompt_file prompt.txt
 
 # セッション再開
 npm run -s cli.run -- --model sonnet --workFolder /tmp --prompt "continue" --session_id <id>
 
 # Codex reasoning effort
-npm run -s cli.run -- --model gpt-5.2-codex --workFolder /tmp --prompt "test" --reasoning_effort high
+npm run -s cli.run -- --model gpt-5.3-codex --workFolder /tmp --prompt "test" --reasoning_effort high
 ```
 
 > **Tip:** `-s` (silent) で npm のスクリプトバナーを抑制します。付けないとリダイレクト時にバナーが混入します。
@@ -146,7 +146,7 @@ This will open a web interface where you can:
 2. Test each tool with different parameters
 3. Test different AI models including:
    - Claude models: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-   - Codex models: `codex` for the CLI default, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
+   - Codex models: `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`
    - Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 
 Example test: Select the `run` tool and provide:

--- a/docs/development.md
+++ b/docs/development.md
@@ -146,7 +146,7 @@ This will open a web interface where you can:
 2. Test each tool with different parameters
 3. Test different AI models including:
    - Claude models: `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku`
-   - Codex models: `codex` for the CLI default, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
+   - Codex models: `codex` for the CLI default, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
    - Gemini models: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro-preview`, `gemini-3-flash-preview`
 
 Example test: Select the `run` tool and provide:

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -78,7 +78,7 @@ Useful environment variables:
 - `ACM_LIVE_E2E_COMMAND_TIMEOUT_MS`: process/request timeout used by the live test harness. Defaults to `ACM_LIVE_E2E_TIMEOUT_SECONDS + 60s`.
 - `ACM_LIVE_E2E_TOKEN`: expected token in the model response. Defaults to `ACM_LIVE_E2E_OK`.
 - `ACM_LIVE_E2E_ASSERT_TOKEN=0`: disables response-token assertion if a provider adds unavoidable formatting.
-- `ACM_LIVE_E2E_<AGENT>_MODEL`: override a default model, for example `ACM_LIVE_E2E_CODEX_MODEL=gpt-5.4`. The default Codex value is `codex`, which uses the Codex CLI's configured default model for account compatibility.
+- `ACM_LIVE_E2E_<AGENT>_MODEL`: override a default model, for example `ACM_LIVE_E2E_CODEX_MODEL=gpt-5.5`. The default Codex value is `codex`, which uses the Codex CLI's configured default model for account compatibility.
 
 Keep this suite out of mandatory CI unless the runner has authenticated CLI sessions, network access, and an acceptable cost budget.
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -78,7 +78,7 @@ Useful environment variables:
 - `ACM_LIVE_E2E_COMMAND_TIMEOUT_MS`: process/request timeout used by the live test harness. Defaults to `ACM_LIVE_E2E_TIMEOUT_SECONDS + 60s`.
 - `ACM_LIVE_E2E_TOKEN`: expected token in the model response. Defaults to `ACM_LIVE_E2E_OK`.
 - `ACM_LIVE_E2E_ASSERT_TOKEN=0`: disables response-token assertion if a provider adds unavoidable formatting.
-- `ACM_LIVE_E2E_<AGENT>_MODEL`: override a default model, for example `ACM_LIVE_E2E_CODEX_MODEL=gpt-5.5`. The default Codex value is `codex`, which uses the Codex CLI's configured default model for account compatibility.
+- `ACM_LIVE_E2E_<AGENT>_MODEL`: override a default model, for example `ACM_LIVE_E2E_CODEX_MODEL=gpt-5.5`. The default Codex value is `gpt-5.4`.
 
 Keep this suite out of mandatory CI unless the runner has authenticated CLI sessions, network access, and an acceptable cost budget.
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -108,7 +108,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 | Provider | Models |
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku` |
-| Codex | `codex` for the CLI default, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5` |
+| Codex | `codex` for the CLI default, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5` |
 | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -108,7 +108,7 @@ AI支援開発において、以下の制約がユーザーの生産性を阻害
 | Provider | Models |
 |---|---|
 | Claude | `sonnet`, `sonnet[1m]`, `opus`, `opusplan`, `haiku` |
-| Codex | `codex` for the CLI default, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5` |
+| Codex | `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` |
 | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3.1-pro-preview`, `gemini-3-pro-preview`, `gemini-3-flash-preview` |
 | Ultra aliases | `claude-ultra`, `codex-ultra`, `gemini-ultra` |
 

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -307,10 +307,17 @@ describe('ai-cli app', () => {
           agent: 'claude',
           defaultReasoningEffort: 'max',
         }),
+        expect.objectContaining({
+          name: 'codex-ultra',
+          resolvesTo: 'gpt-5.5',
+          agent: 'codex',
+          defaultReasoningEffort: 'xhigh',
+        }),
       ])
     );
     expect(payload.claude).toContain('sonnet');
     expect(payload.codex).toContain('codex');
+    expect(payload.codex).toContain('gpt-5.5');
     expect(payload.codex).toContain('gpt-5.4');
     expect(payload.forge).toEqual(['forge']);
     expect(payload.opencode).toEqual(['opencode']);

--- a/src/__tests__/app-cli.test.ts
+++ b/src/__tests__/app-cli.test.ts
@@ -316,9 +316,13 @@ describe('ai-cli app', () => {
       ])
     );
     expect(payload.claude).toContain('sonnet');
-    expect(payload.codex).toContain('codex');
-    expect(payload.codex).toContain('gpt-5.5');
+    expect(payload.codex).not.toContain('codex');
     expect(payload.codex).toContain('gpt-5.4');
+    expect(payload.codex).toContain('gpt-5.5');
+    expect(payload.codex).toContain('gpt-5.4-mini');
+    expect(payload.codex).toContain('gpt-5.3-codex');
+    expect(payload.codex).toContain('gpt-5.3-codex-spark');
+    expect(payload.codex).toContain('gpt-5.2');
     expect(payload.forge).toEqual(['forge']);
     expect(payload.opencode).toEqual(['opencode']);
     expect(payload.dynamicModelBackends).toEqual({
@@ -404,7 +408,7 @@ describe('ai-cli app', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toHaveBeenCalledWith(RUN_HELP_TEXT);
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('claude-ultra'));
-    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.2-codex'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gpt-5.3-codex'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('gemini-2.5-pro'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('forge'));
     expect(stdout).toHaveBeenCalledWith(expect.stringContaining('opencode'));

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -38,8 +38,8 @@ describe('cli-builder', () => {
       expect(resolveModelAlias('claude-ultra')).toBe('opus');
     });
 
-    it('should resolve codex-ultra to gpt-5.4', () => {
-      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.4');
+    it('should resolve codex-ultra to gpt-5.5', () => {
+      expect(resolveModelAlias('codex-ultra')).toBe('gpt-5.5');
     });
 
     it('should resolve gemini-ultra to gemini-3.1-pro-preview', () => {
@@ -419,7 +419,7 @@ describe('cli-builder', () => {
         });
 
         expect(cmd.agent).toBe('codex');
-        expect(cmd.resolvedModel).toBe('gpt-5.4');
+        expect(cmd.resolvedModel).toBe('gpt-5.5');
         expect(cmd.args).toContain('-c');
         expect(cmd.args).toContain('model_reasoning_effort=xhigh');
       });

--- a/src/__tests__/cli-builder.test.ts
+++ b/src/__tests__/cli-builder.test.ts
@@ -48,7 +48,7 @@ describe('cli-builder', () => {
 
     it('should pass through non-alias model names', () => {
       expect(resolveModelAlias('sonnet')).toBe('sonnet');
-      expect(resolveModelAlias('gpt-5.2-codex')).toBe('gpt-5.2-codex');
+      expect(resolveModelAlias('gpt-5.3-codex')).toBe('gpt-5.3-codex');
     });
 
     it('should pass through empty string', () => {
@@ -369,7 +369,7 @@ describe('cli-builder', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
-          model: 'gpt-5.2-codex',
+          model: 'gpt-5.3-codex',
           cliPaths: DEFAULT_CLI_PATHS,
         });
 
@@ -380,7 +380,7 @@ describe('cli-builder', () => {
         expect(cmd.args).not.toContain('--full-auto');
         expect(cmd.args).toContain('--json');
         expect(cmd.args).toContain('--model');
-        expect(cmd.args).toContain('gpt-5.2-codex');
+        expect(cmd.args).toContain('gpt-5.3-codex');
       });
 
       it('should build codex command with session_id using exec resume', () => {
@@ -401,7 +401,7 @@ describe('cli-builder', () => {
         const cmd = buildCliCommand({
           prompt: 'test',
           workFolder: '/tmp',
-          model: 'gpt-5.2-codex',
+          model: 'gpt-5.3-codex',
           reasoning_effort: 'high',
           cliPaths: DEFAULT_CLI_PATHS,
         });

--- a/src/__tests__/live-cli-e2e.test.ts
+++ b/src/__tests__/live-cli-e2e.test.ts
@@ -32,7 +32,7 @@ const tempDirs: string[] = [];
 
 const defaultModels: Record<LiveAgent, string> = {
   claude: 'haiku',
-  codex: 'codex',
+  codex: 'gpt-5.4',
   gemini: 'gemini-2.5-flash',
   forge: 'forge',
   opencode: 'opencode',
@@ -223,7 +223,7 @@ if (liveEnabled) {
         const models = await runAiCliJson(['models'], env);
         expect(models.aliases).toEqual(expect.any(Array));
         expect(models.claude).toContain('haiku');
-        expect(models.codex).toContain('codex');
+        expect(models.codex).toContain('gpt-5.4');
         expect(models.gemini).toContain('gemini-2.5-flash');
         expect(models.forge).toEqual(['forge']);
         expect(models.opencode).toEqual(['opencode']);
@@ -342,7 +342,7 @@ if (liveEnabled) {
           const models = parseToolJson(await client.callTool('models', {}));
           expect(models.aliases).toEqual(expect.any(Array));
           expect(models.claude).toContain('haiku');
-          expect(models.codex).toContain('codex');
+          expect(models.codex).toContain('gpt-5.4');
           expect(models.gemini).toContain('gemini-2.5-flash');
           expect(models.forge).toEqual(['forge']);
           expect(models.opencode).toEqual(['opencode']);

--- a/src/__tests__/mcp-contract.test.ts
+++ b/src/__tests__/mcp-contract.test.ts
@@ -170,7 +170,14 @@ describe('MCP Contract Tests', () => {
       ])
     );
     expect(modelsData.claude).toContain('sonnet');
-    expect(modelsData.codex).toContain('codex');
+    expect(modelsData.codex).toEqual([
+      'gpt-5.4',
+      'gpt-5.5',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex',
+      'gpt-5.3-codex-spark',
+      'gpt-5.2',
+    ]);
     expect(modelsData.opencode).toEqual(['opencode']);
     expect(modelsData.dynamicModelBackends.opencode.explicitPattern).toBe('oc-<provider/model>');
 

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -295,7 +295,7 @@ describe('Argument Validation Tests', () => {
             arguments: {
               prompt: 'test',
               workFolder: '/tmp',
-              model: 'gpt-5.2-codex',
+              model: 'gpt-5.3-codex',
               reasoning_effort: 'fast'
             }
           }

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -28,7 +28,7 @@ Options:
   --cwd <path>                 Working directory
   --prompt <text>              Prompt text
   --prompt-file <path>         Path to a prompt file
-  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.2-codex, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
+  --model <model>              Model name or alias (e.g. sonnet, claude-ultra, gpt-5.3-codex, codex-ultra, gemini-2.5-pro, gemini-ultra, forge, opencode, oc-openai/gpt-5.4)
   --session-id <id>            Resume a previous session, including OpenCode in-place resumes
   --reasoning-effort <level>   Reasoning level for Claude/Codex only; unsupported for Gemini, Forge, and OpenCode
   --help, -h                   Show this help message

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ function parseArgs(argv: string[]): Record<string, string> {
 const USAGE = `Usage: npm run -s cli.run -- --model <model> --workFolder <path> --prompt "..." [options]
 
 Options:
-  --model              Model name or alias (e.g. sonnet, opus, gpt-5.2-codex, gemini-2.5-pro, forge, opencode, oc-openai/gpt-5.4)
+  --model              Model name or alias (e.g. sonnet, opus, gpt-5.3-codex, gemini-2.5-pro, forge, opencode, oc-openai/gpt-5.4)
   --workFolder         Working directory (absolute path)
   --prompt             Prompt string (mutually exclusive with --prompt_file)
   --prompt_file        Path to a file containing the prompt

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,6 +1,7 @@
 export const CLAUDE_MODELS = ['sonnet', 'sonnet[1m]', 'opus', 'opusplan', 'haiku'] as const;
 export const CODEX_MODELS = [
   'codex',
+  'gpt-5.5',
   'gpt-5.4',
   'gpt-5.3-codex',
   'gpt-5.2-codex',
@@ -25,13 +26,13 @@ export const OPENCODE_MODELS = ['opencode'] as const;
 
 export const MODEL_ALIASES: Record<string, string> = {
   'claude-ultra': 'opus',
-  'codex-ultra': 'gpt-5.4',
+  'codex-ultra': 'gpt-5.5',
   'gemini-ultra': 'gemini-3.1-pro-preview',
 };
 
 export const MODEL_ALIAS_DETAILS = [
   { name: 'claude-ultra', resolvesTo: 'opus', agent: 'claude', defaultReasoningEffort: 'max' },
-  { name: 'codex-ultra', resolvesTo: 'gpt-5.4', agent: 'codex', defaultReasoningEffort: 'xhigh' },
+  { name: 'codex-ultra', resolvesTo: 'gpt-5.5', agent: 'codex', defaultReasoningEffort: 'xhigh' },
   { name: 'gemini-ultra', resolvesTo: 'gemini-3.1-pro-preview', agent: 'gemini' },
 ] as const;
 

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,18 +1,11 @@
 export const CLAUDE_MODELS = ['sonnet', 'sonnet[1m]', 'opus', 'opusplan', 'haiku'] as const;
 export const CODEX_MODELS = [
-  'codex',
-  'gpt-5.5',
   'gpt-5.4',
+  'gpt-5.5',
+  'gpt-5.4-mini',
   'gpt-5.3-codex',
-  'gpt-5.2-codex',
-  'gpt-5.1-codex-mini',
-  'gpt-5.1-codex-max',
+  'gpt-5.3-codex-spark',
   'gpt-5.2',
-  'gpt-5.1',
-  'gpt-5.1-codex',
-  'gpt-5-codex',
-  'gpt-5-codex-mini',
-  'gpt-5',
 ] as const;
 export const GEMINI_MODELS = [
   'gemini-2.5-pro',


### PR DESCRIPTION
## Summary

Codex model catalog cleanup: add `gpt-5.5` / `gpt-5.4-mini` / `gpt-5.3-codex-spark`, remove legacy models, and update `codex-ultra` alias to point to `gpt-5.5`.

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Refactoring
- [ ] docs: Documentation
- [ ] test: Add or update tests
- [ ] chore: Build, CI, dependencies, etc.

## Changes

- Remove the generic `codex` alias (which deferred to the Codex CLI's configured default) from `CODEX_MODELS`
- Add `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` to `CODEX_MODELS`
- Remove legacy models: `gpt-5.2-codex`, `gpt-5.1-codex-mini`, `gpt-5.1-codex-max`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
- Update `codex-ultra` alias: `gpt-5.4` → `gpt-5.5`
- Keep `gpt-5.4` as the default advertised Codex model
- Update all tests and docs to reflect new model catalog

## Test Plan

- [x] `npm run test:release` passes (deterministic gate; real live E2E is separate)
- [ ] Release-time live E2E passes when the change can affect CLI execution (`ACM_LIVE_E2E=1 ACM_LIVE_E2E_SURFACE=all ACM_LIVE_E2E_AGENTS=claude,codex npm run test:live`)
- [ ] Manual testing (if applicable)

## Notes

<!-- Any additional context for reviewers -->
